### PR TITLE
[LG-181] Endpoint to verify token and return contents

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -1,0 +1,14 @@
+require 'cgi'
+require 'openssl'
+
+class VerifyController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def open
+    # TODO: secure this endpoint against public use
+    token = params.require(:token)
+    render json: TokenService.open(token)
+  rescue ActionController::ParameterMissing
+    render json: { error: 'token.missing' }
+  end
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,0 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/app/models/piv_cac.rb
+++ b/app/models/piv_cac.rb
@@ -24,15 +24,6 @@ class PivCac < ApplicationRecord
       end
     end
 
-    def find_by(opts = {})
-      dn = opts[:dn]
-      if dn
-        super(opts.except(:dn).merge(dn_signature: make_dn_signature(dn)))
-      else
-        super
-      end
-    end
-
     def make_dn_signature(raw)
       Base64.encode64(OpenSSL::Digest.digest(DN_SIGNATURE_HASH, raw)).chomp if raw
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/', to: 'identify#create'
+  post '/', to: 'verify#open'
 end

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+require 'uri'
+
+RSpec.describe VerifyController, type: :controller do
+  let(:token) do
+    TokenService.box(token_contents)
+  end
+
+  let(:token_contents) do
+    {
+      'token' => 'value',
+    }
+  end
+
+  describe 'POST /' do
+    it 'without a token returns an error' do
+      post :open
+      expect(response).to be_successful
+
+      data = JSON.parse(response.body)
+      expect(data).to eq('error' => 'token.missing')
+    end
+
+    it 'returns the contents of the token' do
+      post :open, params: { token: token }
+      expect(response).to be_successful
+
+      data = JSON.parse(response.body)
+      expect(data).to eq token_contents
+    end
+
+    describe 'with a bad token' do
+      let(:token) { SecureRandom.base64(123) }
+
+      it 'returns an error' do
+        post :open, params: { token: token }
+        expect(response).to be_successful
+
+        data = JSON.parse(response.body)
+        expect(data).to eq('error' => 'token.invalid')
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
When we give identity-idp a token from identity-pki, we
need the IdP to know what the token represents. This
endpoint provides that.

**How**:
We unwrap the token and return the contents. We are not
yet securing this endpoint