### PR TITLE
[LG-185] Rake tasks to dump certs and graph relationships

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -5,7 +5,8 @@ class Certificate
     @x509_cert = x509_cert
   end
 
-  def_delegators :@x509_cert, :not_before, :not_after, :subject, :verify, :public_key, :serial
+  def_delegators :@x509_cert, :not_before, :not_after, :subject, :issuer, :verify,
+                 :public_key, :serial
 
   def trusted_root?
     CertificateStore.trusted_ca_root_identifiers.include?(key_id)
@@ -27,6 +28,14 @@ class Certificate
   def valid?
     !expired? &&
       (trusted_root? || !self_signed? && !revoked? && signature_verified?)
+  end
+
+  def to_pem
+    <<~PEM
+      Subject: #{subject}
+      Issuer: #{issuer}
+      #{@x509_cert.to_pem}
+    PEM
   end
 
   # :reek:UtilityFunction

--- a/lib/tasks/ca.rake
+++ b/lib/tasks/ca.rake
@@ -1,0 +1,22 @@
+namespace :ca do
+  desc 'dump CA certificates'
+  task dump: :environment do
+    puts CertificateStore.instance.map { |_, cert| cert.to_pem }.join("\n")
+  end
+
+  desc 'graph CA certificate relationships'
+  task graph: :environment do
+    uml = +''
+    uml << "@startuml\n"
+    CertificateStore.instance.each do |cert|
+      uml << "file \"#{cert.subject}\" as Cert#{cert.key_id.delete(':')}\n"
+    end
+    CertificateStore.instance.each do |cert|
+      next if cert.trusted_root?
+      uml << "Cert#{cert.signing_key_id.delete(':')} -down-> Cert#{cert.key_id.delete(':')}\n"
+    end
+    uml << "@enduml\n"
+
+    puts uml
+  end
+end


### PR DESCRIPTION
**Why**:
We want to share the trusted set of certificates with
Nginx.
    
**How**:
A rake task to dump the list of verified certificates that
we can trace back to a trusted root. As part of this, we
also have a rake task to create a plantuml diagram of how
the certificates are related to the trusted root(s).