### PR TITLE
Handle unescaped X509 certs

### DIFF
--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -22,13 +22,23 @@ class IdentifyController < ApplicationController
 
   # :reek:UtilityFunction
   def token_for_referrer
-    cert_pem = request.headers[CERT_HEADER]
+    cert_pem = client_cert
     token = if cert_pem
-              process_cert(CGI.unescape(cert_pem))
+              process_cert(cert_pem)
             else
               TokenService.box(error: 'certificate.none', nonce: nonce)
             end
     CGI.escape(token)
+  end
+
+  def client_cert
+    cert_pem = request.headers[CERT_HEADER]
+    return unless cert_pem
+    if Figaro.env.client_cert_escaped == 'true'
+      CGI.unescape(cert_pem)
+    else
+      cert_pem.delete("\t")
+    end
   end
 
   # :reek:UtilityFunction

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -8,11 +8,13 @@
 trusted_ca_root_identifiers: "AD:0C:7A:75:5C:E5:F3:98:C4:79:98:0E:AC:28:FD:97:F4:E7:02:FC"
 
 development:
+  client_cert_escaped: 'true'
   database_name: 'identity_pki_dev'
   token_encryption_key_salt: 23df6c812fb1ca9c17debee3a91aba30bc0e85c38b414ee59a9e3d3eb5ec5c0221e2558cac8a808375711cb1450a9db40b8aec74f147e4a3e15dc3c304f1b23e
   token_encryption_key_pepper: c6b4a68a3adf0ff2069d5240bb71532c7a8c0dbb77bba5f9070e2d8ab1ebcc918cc8d8cdbb04fa34ed71126fac3e02d9c85280ae0f7c42d22b678e3e5eb67cfe
 
 test:
+  client_cert_escaped: 'true'
   database_name: 'identity_pki_test'
   token_encryption_key_salt: 23df6c812fb1ca9c17debee3a91aba30bc0e85c38b414ee59a9e3d3eb5ec5c0221e2558cac8a808375711cb1450a9db40b8aec74f147e4a3e15dc3c304f1b23e
   token_encryption_key_pepper: c6b4a68a3adf0ff2069d5240bb71532c7a8c0dbb77bba5f9070e2d8ab1ebcc918cc8d8cdbb04fa34ed71126fac3e02d9c85280ae0f7c42d22b678e3e5eb67cfe


### PR DESCRIPTION
**Why**:
Different versions of Nginx have different ways
of handling client certs in headers. We need to
handle both ways.
    
**How**:
Provide a flag that indicates if the cert in the
header is escaped.