### PR TITLE
[LG-183] Whitelist referrer for redirect

### DIFF
--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -64,9 +64,14 @@ class IdentifyController < ApplicationController
         value = URI(value)
         value.query = ''
         value.fragment = ''
-        # TODO: LG-183 - make sure referrer is whitelisted
       end
-      value
+      value if value && allowed_referrer?(value)
     end
+  end
+
+  # :reek:UtilityFunction
+  def allowed_referrer?(uri)
+    allowed_host = Figaro.env.identity_idp_host
+    !allowed_host || uri.host == allowed_host
   end
 end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -10,11 +10,13 @@ trusted_ca_root_identifiers: "AD:0C:7A:75:5C:E5:F3:98:C4:79:98:0E:AC:28:FD:97:F4
 development:
   client_cert_escaped: 'true'
   database_name: 'identity_pki_dev'
+  identity_idp_host: 'localhost'
   token_encryption_key_salt: 23df6c812fb1ca9c17debee3a91aba30bc0e85c38b414ee59a9e3d3eb5ec5c0221e2558cac8a808375711cb1450a9db40b8aec74f147e4a3e15dc3c304f1b23e
   token_encryption_key_pepper: c6b4a68a3adf0ff2069d5240bb71532c7a8c0dbb77bba5f9070e2d8ab1ebcc918cc8d8cdbb04fa34ed71126fac3e02d9c85280ae0f7c42d22b678e3e5eb67cfe
 
 test:
   client_cert_escaped: 'true'
   database_name: 'identity_pki_test'
+  identity_idp_host: 'localhost'
   token_encryption_key_salt: 23df6c812fb1ca9c17debee3a91aba30bc0e85c38b414ee59a9e3d3eb5ec5c0221e2558cac8a808375711cb1450a9db40b8aec74f147e4a3e15dc3c304f1b23e
   token_encryption_key_pepper: c6b4a68a3adf0ff2069d5240bb71532c7a8c0dbb77bba5f9070e2d8ab1ebcc918cc8d8cdbb04fa34ed71126fac3e02d9c85280ae0f7c42d22b678e3e5eb67cfe

--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -12,12 +12,25 @@ RSpec.describe IdentifyController, type: :controller do
 
   describe 'GET /' do
     it 'without a referrer returns http bad request' do
-      get :create
+      get :create, params: { nonce: '123' }
       expect(response).to have_http_status(:bad_request)
     end
 
-    describe 'with a referrer' do
+    describe 'with a bad referrer' do
       before(:each) do
+        allow(Figaro.env).to receive(:identity_idp_host).and_return('example.org')
+        @request.headers['Referer'] = 'http://example.com/'
+      end
+
+      it 'returns http bad request' do
+        get :create, params: { nonce: '123' }
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    describe 'with a good referrer' do
+      before(:each) do
+        allow(Figaro.env).to receive(:identity_idp_host).and_return('example.com')
         @request.headers['Referer'] = 'http://example.com/'
       end
 


### PR DESCRIPTION
**Why**:
We don't want someone using the piv/cac service
for anything other than login.gov.
    
**How**:
Ensure the host of the referring url, and thus
the redirect, is what we expect it to be. 