### PR TITLE
[LG-184] Log unknown certificate authorities

### DIFF
--- a/.reek
+++ b/.reek
@@ -5,6 +5,9 @@ IrresponsibleModule:
   enabled: false
 NilCheck:
   enabled: false
+TooManyMethods:
+  exclude:
+    - Certificate
 'spec':
   DuplicateMethodCall:
     enabled: false

--- a/app/models/unrecognized_certificate_authority.rb
+++ b/app/models/unrecognized_certificate_authority.rb
@@ -1,0 +1,13 @@
+class UnrecognizedCertificateAuthority < ApplicationRecord
+  validates :key, presence: true, uniqueness: true, case_sensitive: false,
+                  format: { with: /\A(\h{2})(:\h{2})+\Z/ }
+  validates :dn, presence: true
+
+  def self.find_or_create_for_certificate(certificate)
+    return if certificate.issuer.blank?
+
+    create_with(
+      certificate.issuer_metadata
+    ).find_or_create_by(key: certificate.signing_key_id)
+  end
+end

--- a/db/migrate/20180517192853_create_unrecognized_certificate_authorities_table.rb
+++ b/db/migrate/20180517192853_create_unrecognized_certificate_authorities_table.rb
@@ -1,0 +1,14 @@
+class CreateUnrecognizedCertificateAuthoritiesTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :unrecognized_certificate_authorities do |t|
+      t.string :key, null: false
+      t.string :dn, null: false
+      t.string :crl_http_url
+      t.string :ocsp_url
+      t.string :ca_issuer_url
+      t.timestamps
+
+      t.index :key, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_19_202740) do
+ActiveRecord::Schema.define(version: 2018_05_17_192853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,17 @@ ActiveRecord::Schema.define(version: 2018_04_19_202740) do
     t.string "dn_signature", null: false
     t.index ["dn_signature"], name: "index_piv_cacs_on_dn_signature", unique: true
     t.index ["uuid"], name: "index_piv_cacs_on_uuid", unique: true
+  end
+
+  create_table "unrecognized_certificate_authorities", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "dn", null: false
+    t.string "crl_http_url"
+    t.string "ocsp_url"
+    t.string "ca_issuer_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_unrecognized_certificate_authorities_on_key", unique: true
   end
 
   add_foreign_key "certificate_revocations", "certificate_authorities"

--- a/spec/factories/unrecognized_certificate_authorities.rb
+++ b/spec/factories/unrecognized_certificate_authorities.rb
@@ -1,0 +1,8 @@
+require 'securerandom'
+
+FactoryBot.define do
+  factory :unrecognized_certificate_authority do
+    key { SecureRandom.hex(20).gsub(/(..)/, '\\1:').chomp(':').upcase }
+    sequence(:dn) { |n| "O=Unseen University, OU=testing CN=Certificate #{n}" }
+  end
+end

--- a/spec/models/unrecognized_certificate_authority_spec.rb
+++ b/spec/models/unrecognized_certificate_authority_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe UnrecognizedCertificateAuthority, type: :model do
+  let(:authority) { create(:unrecognized_certificate_authority) }
+
+  subject { authority }
+  it { is_expected.to validate_uniqueness_of(:key) }
+  it { is_expected.to validate_presence_of(:dn) }
+end

--- a/spec/support/x509.rb
+++ b/spec/support/x509.rb
@@ -5,6 +5,12 @@ module X509Helpers
   # We aren't making real certificates, just realistic ones.
   RSA_KEY_SIZE = 512
 
+  AUTHORITY_INFO_ACCESS_EXTENSION = [
+    'authorityInfoAccess',
+    'caIssuers;URI:http://example.com/,OCSP;URI:http://ocsp.example.com/',
+    false,
+  ].freeze
+
   ##
   # Requires:
   # ca: the issuing cert
@@ -78,6 +84,7 @@ module X509Helpers
     add_certificate_extensions(cert, root_ca,
                                ['basicConstraints', 'CA:TRUE', true],
                                ['keyUsage', 'keyCertSign, cRLSign', true],
+                               AUTHORITY_INFO_ACCESS_EXTENSION,
                                ['subjectKeyIdentifier', 'hash', false],
                                ['authorityKeyIdentifier', 'keyid:always', false])
     cert.sign(root_key, OpenSSL::Digest::SHA256.new)
@@ -106,6 +113,7 @@ module X509Helpers
     add_certificate_extensions(cert, root_ca,
                                ['keyUsage', 'digitalSignature', true],
                                ['subjectKeyIdentifier', 'hash', false],
+                               AUTHORITY_INFO_ACCESS_EXTENSION,
                                ['authorityKeyIdentifier', 'keyid:always', false])
     cert.sign(root_key, OpenSSL::Digest::SHA256.new)
     cert


### PR DESCRIPTION
**Why**:
We want to know about certificate authorities that
we may need to track down to support users.

**How**:
Rather than log the certificates, we log metadata
about the issuing certificate.