### PR TITLE
[LG-202] Validate CRL signatures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,15 +28,14 @@ jobs:
 
       - restore-cache:
           keys:
-            - identity-pki-bundle-{{ checksum "Gemfile.lock" }}
-            - identity-pki-bundle-
+            - v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install dependencies
           command: |
             gem install bundler
             bundle check || bundle install --deployment --jobs=4 --retry=3 --without deploy development doc production --path vendor/bundle
       - save-cache:
-          key: identity-pki-bundle-{{ checksum "Gemfile.lock" }}
+          key: v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '~> 2.3.5'
 
 gem 'rails', '~> 5.2'
 
+gem 'activerecord-import'
 gem 'figaro'
 gem 'health_check'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       activemodel (= 5.2.0)
       activesupport (= 5.2.0)
       arel (>= 9.0)
+    activerecord-import (0.23.0)
+      activerecord (>= 3.2)
     activestorage (5.2.0)
       actionpack (= 5.2.0)
       activerecord (= 5.2.0)
@@ -315,6 +317,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   axe-matchers (~> 1.3.4)
   better_errors
   binding_of_caller
@@ -353,4 +356,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -77,3 +77,50 @@ restart the server. See the [rack_mini_profiler] gem for more details.
 
 Once it is up and running, the app will be accessible at
 `http://localhost:3001/` by default.
+
+### Certificate Authority Management
+
+The PIV/CAC service relies on having all of the certificate authorities (issuing
+certificates). If a certificate authority is missing, then any client certificates
+signed by that authority will not be recognized as valid.
+
+All certificates have to link back to a trusted root. Trusted roots are implicitly
+trusted as long as they aren't expired. Any certificate authority that can't be
+traced back to a trusted root will be ignored.
+
+Certificate authorities are made trusted roots by listing their key id in the
+`config/application.yml`. The `trusted_ca_root_identifiers` configuration attribute
+is a comma-delimited list of key ids.
+
+#### Managing Certificate Revocation Lists (CRLs)
+
+The application does not download CRLs. Instead, it expects revoked serial numbers to
+be listed in the `certificate_revocations` table.
+
+##### Loading CRL Metadata
+
+Use the `rake crls:load` command to load a CSV of CRL metadata into the database. This
+command takes an optional filename argument if you aren't providing the CSV on STDIN.
+
+The CSV has the following columns:
+1. certificate authority key id
+2. valid not before date/time
+3. valid not after date/time
+4. certificate authority subject
+5. CRL HTTP URL
+
+##### Dumping CRL Metadata
+
+Use the `rake crls:dump` command to dump a CSV of CRL metadata from the database. This
+command takes an optional filename argument if you aren't wanting the CSV on STDOUT.
+
+The CSV has the same columns as for `crls:load`.
+
+##### Updating CRLs
+
+Use the `rake crls:update` command to fetch the CRLs of configured certificate authorities
+and add any serial numbers to the database.
+
+N.B.: Because of the CRL security model, the command will not fetch or update CRLs for
+certificate authorities that aren't linked to a trusted root. Make sure your trusted roots
+are configured if you aren't seeing CRLs fetched as you expect.

--- a/lib/tasks/crls.rake
+++ b/lib/tasks/crls.rake
@@ -1,14 +1,61 @@
+require 'csv'
+
 namespace :crls do
   desc 'update CRL entries in the database'
   task update: :environment do
+    # The timeout value isn't significant as long as it is large since we're doing
+    # bulk inserts that can take a while to execute.
+    ActiveRecord::Base.connection.execute('set statement_timeout to 1000000')
     CertificateAuthority.
       with_crl_http_url.
-      includes(:certificate_revocations).
       find_each do |authority|
       begin
+        Rails.logger.info "Updating #{authority.key} #{authority.dn} <#{authority.crl_http_url}>"
         authority.update_revocations
       rescue StandardError => e
-        puts "Unable to update CRL from <#{certificate.crl_http_url}>: #{e}"
+        Rails.logger.warn "  Unable to update CRL from <#{authority.crl_http_url}>: #{e}"
+      end
+    end
+  end
+
+  desc 'dump CRL information from database into a CSV file'
+  task :dump, [:file] => :environment do |_task, args|
+    file = args[:file]
+    csv = if file.blank? || file == '-'
+            CSV($stdout)
+          else
+            CSV.open(file, 'wb')
+          end
+
+    CertificateAuthority.find_each do |authority|
+      csv << [
+        authority.key,
+        authority.valid_not_before,
+        authority.valid_not_after,
+        authority.dn,
+        authority.crl_http_url,
+      ]
+    end
+  end
+
+  desc 'load CRL information into database from a CSV file'
+  task :load, [:file] => :environment do |_task, args|
+    file = args[:file]
+    csv = if file.blank? || file == '-'
+            CSV($stdin)
+          else
+            CSV.open(file, 'rb')
+          end
+    csv.each do |(key, valid_not_before, valid_not_after, dn, crl_http_url, *_rest)|
+      record = CertificateAuthority.create_with(
+        valid_not_before: valid_not_before,
+        valid_not_after: valid_not_after,
+        crl_http_url: crl_http_url
+      ).find_or_create_by(key: key, dn: dn)
+
+      if crl_http_url.present? && crl_http_url != record.crl_http_url
+        record.crl_http_url = crl_http_url
+        record.save
       end
     end
   end


### PR DESCRIPTION
**Why**:
CRLs aren't sent over HTTPS because that requires
validating a certificate. It's turtles all the way
down. So instead, CRLs are signed by the issuing
certificate.

**How**:
We make sure that the CRL is signed by a certificate
we have in-hand. More importantly, it's signed by the
certificate with which the CRL URL is associated.

This PR also adds two rake tasks to dump/load CRL
metadata from the database. Also makes the loading
of CRLs themselves faster.