### PR TITLE
Add the healthcheck gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'figaro'
 gem 'pg'
 gem 'puma', '~> 3.7'
 gem 'rgl'
+gem "health_check"
 
 group :development, :test do
   gem 'bullet'

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,10 @@ ruby '~> 2.3.5'
 gem 'rails', '~> 5.2'
 
 gem 'figaro'
+gem 'health_check'
 gem 'pg'
 gem 'puma', '~> 3.7'
 gem 'rgl'
-gem "health_check"
 
 group :development, :test do
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.7)
+    health_check (3.0.0)
+      railties (>= 5.0)
     heapy (0.1.3)
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
@@ -326,6 +328,7 @@ DEPENDENCIES
   fasterer
   figaro
   guard-rspec
+  health_check
   overcommit
   pg
   pry-byebug


### PR DESCRIPTION
With no customization, this just adds a route at /health_check that ensures the app is running. AWS can access this on each host and take them out of the ELB if they're not healthy.