### PR TITLE
Refactor cert validation logic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Metrics/ClassLength:
   # Max: 100
   Exclude:
   - spec/**/*
+  - app/models/certificate.rb
 
 Metrics/LineLength:
   Description: Limit lines to 100 characters.

--- a/app/models/certificate_authority.rb
+++ b/app/models/certificate_authority.rb
@@ -37,6 +37,7 @@ class CertificateAuthority < ApplicationRecord
 
   def self.revoked?(key_id, serial)
     cert = find_by(key: key_id)
-    !cert || cert.revoked?(serial)
+    # Cert should exist and not be revoked.
+    cert&.revoked?(serial)
   end
 end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Certificate do
     it { expect(certificate.ca_capable?).to be_truthy }
     it { expect(certificate.self_signed?).to be_truthy }
     it { expect(certificate.valid?).to be_falsey }
-    it { expect(certificate_error).to eq 'certificate.unverified' }
+    it { expect(certificate_error).to eq 'certificate.self-signed cert' }
   end
 
   describe 'a leaf cert' do


### PR DESCRIPTION
1. Move the validation boolean logic into the same method that generates the rejection reasons, so they always come up with the same answer.

2. Clarify the behavior of the "revoked?" method so that nonexistence is not the same as revocation.

3. Log the cert verdict each time. (Do NOT log the subject.)