### PR TITLE
Support proxy for CRL access

### DIFF
--- a/app/services/certificate_revocation_list_service.rb
+++ b/app/services/certificate_revocation_list_service.rb
@@ -30,10 +30,8 @@ class CertificateRevocationListService
 
     def fetch_crl(url)
       raise NO_CRL_URL_ERROR if url.blank?
-      parsed_url = URI(url)
-      http = Net::HTTP.new(parsed_url.hostname)
-      response = http.get(parsed_url.path)
 
+      response = get_response(url)
 
       case response
       when Net::HTTPSuccess then
@@ -42,6 +40,12 @@ class CertificateRevocationListService
         Rails.logger.warn "  unable to fetch <#{url}>: #{response.message}"
         nil
       end
+    end
+
+    def get_response(url)
+      parsed_url = URI(url)
+      http = Net::HTTP.new(parsed_url.hostname)
+      http.get(parsed_url.path)
     end
   end
 end

--- a/app/services/certificate_revocation_list_service.rb
+++ b/app/services/certificate_revocation_list_service.rb
@@ -30,7 +30,10 @@ class CertificateRevocationListService
 
     def fetch_crl(url)
       raise NO_CRL_URL_ERROR if url.blank?
-      response = Net::HTTP.get_response(URI(url))
+      parsed_url = URI(url)
+      http = Net::HTTP.new(parsed_url.hostname)
+      response = http.get(parsed_url.path)
+
 
       case response
       when Net::HTTPSuccess then

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -64,8 +64,10 @@ describe Deploy::Activate do
 
       # top-level key from application.yml.example
       expect(combined_application_yml['trusted_ca_root_identifiers']).not_to be_empty
-      # six fingerprints, each of length 59, separated by four commas
-      expect(combined_application_yml['trusted_ca_root_identifiers'].length).to eq(TRUSTED_ROOT_COUNT * 59 + TRUSTED_ROOT_COUNT - 1)
+      # ___ fingerprints, each of length 59, separated by ___ - 1 commas
+      expect(combined_application_yml['trusted_ca_root_identifiers'].length).to eq(
+        TRUSTED_ROOT_COUNT * 59 + TRUSTED_ROOT_COUNT - 1
+      )
       # overridden production key from s3
       expect(combined_application_yml['production']['secret_key_base']).to eq('this is a secret')
       # production key from applicaiton.yml.example, not overwritten


### PR DESCRIPTION
**Why**:
We use a proxy to reach systems outside our deployment environment.
All other outgoing connections are blocked.

**How**:
Rather than use some of the helper methods from Net::HTTP, we have
to do a bit more hand-holding to get Net::HTTP to recognize the
proxy.