### PR TITLE
Support proxies for OCSP requests

### DIFF
--- a/app/services/ocsp_service.rb
+++ b/app/services/ocsp_service.rb
@@ -58,9 +58,8 @@ class OCSPService
 
   # :reek:UtilityFunction
   def make_single_http_request(uri, request)
-    Net::HTTP.start(uri.hostname, uri.port) do |http|
-      http.post(uri.path.presence || '/', request, 'content-type' => 'application/ocsp-request')
-    end
+    http = Net::HTTP.new(uri.hostname, uri.port)
+    http.post(uri.path.presence || '/', request, 'content-type' => 'application/ocsp-request')
   end
 
   # :reek:UtilityFunction


### PR DESCRIPTION
**Why**:
We use a proxy to mediate between our web servers and the
outside world.

**How**:
Use the Net::HTTP invocation that respects proxy settings.