### PR TITLE
Fix an edge case for OCSP

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -98,7 +98,7 @@ class Certificate
   end
 
   def aia
-    get_extension('authorityInfoAccess')&.
+    @aia ||= get_extension('authorityInfoAccess')&.
       split(/\n/)&.
       map { |line| line.split(/\s*-\s*/, 2) }&.
       each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(key, value), memo|
@@ -116,11 +116,11 @@ class Certificate
   end
 
   def ca_issuer_http_url
-    extract_http_url(aia['CA Issuers'])
+    extract_http_url(aia['CA Issuers']) if aia.present?
   end
 
   def ocsp_http_url
-    extract_http_url(aia['OCSP'])
+    extract_http_url(aia['OCSP']) if aia.present?
   end
 
   def issuer_metadata

--- a/app/services/certificate_store.rb
+++ b/app/services/certificate_store.rb
@@ -63,7 +63,7 @@ class CertificateStore
   def x509_certificate_chain(cert)
     trusted_ca_root_identifiers.each do |cert_root_id|
       sequence = x509_certificate_chain_to_root(cert, cert_root_id)
-      return sequence if sequence&.any?
+      return sequence if sequence&.any? && sequence&.all?
     end
     []
   end

--- a/app/services/certificate_store.rb
+++ b/app/services/certificate_store.rb
@@ -74,6 +74,8 @@ class CertificateStore
     @certificates.values_at(
       *@graph.dijkstra_shortest_path(Hash.new(1), signing_key_id, cert_root_id)
     )
+  rescue RGL::NoVertexError
+    []
   end
 
   def delete(key)

--- a/spec/models/certificate_authority_spec.rb
+++ b/spec/models/certificate_authority_spec.rb
@@ -73,6 +73,17 @@ RSpec.describe CertificateAuthority, type: :model do
         stub_request(:get, crl_http_url).to_return(body: crl_content)
       end
 
+      describe 'that returns a 404' do
+        before(:each) do
+          stub_request(:get, crl_http_url).to_return(status: 404, body: '')
+        end
+
+        it 'logs to the Rails log' do
+          expect(Rails.logger).to receive(:warn)
+          authority.update_revocations
+        end
+      end
+
       it 'pulls the content via a GET' do
         authority.update_revocations
 

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -87,6 +87,42 @@ RSpec.describe Certificate do
     end
   end
 
+  describe '#ocsp_http_url' do
+    let(:x509_cert) { leaf_cert }
+
+    it 'has an OCSP url' do
+      expect(certificate.ocsp_http_url).to be_present
+    end
+
+    context 'with no AIA extension' do
+      before(:each) do
+        allow(certificate).to receive(:aia).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(certificate.ocsp_http_url).to be_nil
+      end
+    end
+  end
+
+  describe '#ca_issuer_http_url' do
+    let(:x509_cert) { leaf_cert }
+
+    it 'has an OCSP url' do
+      expect(certificate.ca_issuer_http_url).to be_present
+    end
+
+    context 'with no AIA extension' do
+      before(:each) do
+        allow(certificate).to receive(:aia).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(certificate.ca_issuer_http_url).to be_nil
+      end
+    end
+  end
+
   describe 'a root cert' do
     let(:x509_cert) { root_cert }
 

--- a/spec/models/piv_cac_spec.rb
+++ b/spec/models/piv_cac_spec.rb
@@ -8,4 +8,10 @@ RSpec.describe PivCac, type: :model do
   it { is_expected.to validate_uniqueness_of :uuid }
   it { is_expected.to validate_presence_of :dn_signature }
   it { is_expected.to validate_uniqueness_of :dn_signature }
+
+  describe '#find_or_create_by' do
+    it 'returns nil when dn is not provided' do
+      expect(described_class.find_or_create_by(uuid: 'some-uuid').errors).to_not be_empty
+    end
+  end
 end

--- a/spec/services/certificate_store_spec.rb
+++ b/spec/services/certificate_store_spec.rb
@@ -140,6 +140,15 @@ RSpec.describe CertificateStore do
         end
       end
 
+      describe 'with an invalid trusted root id' do
+        it 'has no chain' do
+          cert = leaf_certs.first
+          allow(cert).to receive(:signing_key_id).and_return('NOT:A:REAL:CERTIFICATE:KEY:ID')
+          chain_ids = certificate_store.x509_certificate_chain(cert)
+          expect(chain_ids).to be_empty
+        end
+      end
+
       describe 'with no intermediates' do
         let(:ca_file_content) do
           certificates_in_collection(cert_collection, :type, :root).

--- a/spec/services/ocsp_service_spec.rb
+++ b/spec/services/ocsp_service_spec.rb
@@ -218,7 +218,6 @@ RSpec.describe OCSPService do
     end
   end
 
-
   context 'with invalid OCSP response' do
     let(:ca_file_path) { data_file_path('certs.pem') }
 


### PR DESCRIPTION
**Why**:
Not all certs we encounter will have AIA extensions.

**How**:
Check that we have AIA info before assuming we do. Also, make
sure a cert chain has no nil members.