### PR TITLE
Log OCSP responses

### DIFF
--- a/app/models/ocsp_response.rb
+++ b/app/models/ocsp_response.rb
@@ -46,7 +46,11 @@ class OCSPResponse
 
   def any_revoked?
     return unless response
-    response.basic.status.any? { |status| status[1] == OpenSSL::OCSP::V_CERTSTATUS_REVOKED }
+    expected_serial = subject.serial
+    response.basic.status.any? do |status|
+      status[0].serial == expected_serial &&
+        status[1] == OpenSSL::OCSP::V_CERTSTATUS_REVOKED
+    end
   end
 
   def logging_filename

--- a/app/models/ocsp_response.rb
+++ b/app/models/ocsp_response.rb
@@ -40,6 +40,9 @@ class OCSPResponse
   # 2 and 3 can't happen since we set it in the request; 0 is always an error
   # whether or not we accept -1 depends on if we expect all OCSP responders
   # to echo back our nonce. We'll be forgiving for now.
+  #
+  # Entrust caches their OCSP responses, so we can't expect a nonce in their responses.
+  #
   def valid_nonce?
     !request.check_nonce(response.basic).zero?
   end

--- a/app/models/ocsp_response.rb
+++ b/app/models/ocsp_response.rb
@@ -10,6 +10,10 @@ class OCSPResponse
 
   def_delegators :@ocsp_request, :subject, :request, :authority
 
+  def successful?
+    response&.status&.zero?
+  end
+
   def revoked?
     return unless verified? && valid_nonce?
     any_revoked?
@@ -24,11 +28,7 @@ class OCSPResponse
     # This will spit out a warning if the response is not signed by
     # the cert we expect since we won't have the unexpected signing
     # cert in the chain. That's okay.
-    response&.verify(chain, cert_store.store, OpenSSL::OCSP::TRUSTOTHER)
-  end
-
-  def valid_nonce?
-    !request.check_nonce(response).zero?
+    response&.basic&.verify(chain, cert_store.store, OpenSSL::OCSP::TRUSTOTHER)
   end
 
   # -1 == nonce in request only
@@ -40,7 +40,63 @@ class OCSPResponse
   # 2 and 3 can't happen since we set it in the request; 0 is always an error
   # whether or not we accept -1 depends on if we expect all OCSP responders
   # to echo back our nonce. We'll be forgiving for now.
+  def valid_nonce?
+    !request.check_nonce(response.basic).zero?
+  end
+
   def any_revoked?
-    response.status.any? { |status| status[1] == OpenSSL::OCSP::V_CERTSTATUS_REVOKED }
+    return unless response
+    response.basic.status.any? { |status| status[1] == OpenSSL::OCSP::V_CERTSTATUS_REVOKED }
+  end
+
+  def logging_filename
+    'OCSP:' + subject.logging_filename
+  end
+
+  def logging_content
+    if response
+      content = subject.to_pem
+      content << to_pem
+      content << to_text
+    else
+      content = "No Response\n"
+    end
+    content
+  end
+
+  def to_pem
+    "----- BEGIN OCSP -----\n" +
+      Base64.encode64(response.to_der) +
+      "----- END OCSP -----\n"
+  end
+
+  def to_text
+    general_text_description +
+      "Basic Response:\n  Responses:\n" +
+      response.basic.status.map { |status| status_description(status) }.join('')
+  end
+
+  private
+
+  def general_text_description
+    "Subject Serial: #{subject.serial}\n" \
+      "Status String: #{response.status_string}\n" \
+      "Status Int: #{response.status}\n"
+  end
+
+  STATUS_STRINGS = {
+    OpenSSL::OCSP::V_CERTSTATUS_REVOKED => 'revoked',
+    OpenSSL::OCSP::V_CERTSTATUS_GOOD => 'good',
+    OpenSSL::OCSP::V_CERTSTATUS_UNKNOWN => 'unknown',
+  }.freeze
+
+  # :reek:UtilityFunction
+  def status_description(status)
+    (certid, status_code, reason_code) = status
+    "    - Status Int: #{status_code}\n" \
+      "      Status String: #{STATUS_STRINGS[status_code] || 'other'}\n" \
+      "      Reason Int: #{reason_code}\n" \
+      "      Cert Id:\n" \
+      "        Serial: #{certid.serial}\n"
   end
 end

--- a/app/models/ocsp_response.rb
+++ b/app/models/ocsp_response.rb
@@ -15,7 +15,7 @@ class OCSPResponse
   end
 
   def revoked?
-    return unless verified? && valid_nonce?
+    return unless successful? && verified? && valid_nonce?
     any_revoked?
   end
 
@@ -55,13 +55,10 @@ class OCSPResponse
 
   def logging_content
     if response
-      content = subject.to_pem
-      content << to_pem
-      content << to_text
+      [subject.to_pem, to_pem, to_text].join("\n")
     else
-      content = "No Response\n"
+      'No Response'
     end
-    content
   end
 
   def to_pem
@@ -93,6 +90,7 @@ class OCSPResponse
   # :reek:UtilityFunction
   def status_description(status)
     (certid, status_code, reason_code) = status
+    reason_code = status_code == OpenSSL::OCSP::V_CERTSTATUS_REVOKED ? reason_code : '-'
     "    - Status Int: #{status_code}\n" \
       "      Status String: #{STATUS_STRINGS[status_code] || 'other'}\n" \
       "      Reason Int: #{reason_code}\n" \

--- a/app/services/certificate_logger_service.rb
+++ b/app/services/certificate_logger_service.rb
@@ -8,6 +8,12 @@ class CertificateLoggerService
       obj.put(body: certificate.logging_content)
     end
 
+    def log_ocsp_response(response)
+      return if bucket.blank? || !response.response
+      obj = bucket.object(response.logging_filename)
+      obj.put(body: response.logging_content)
+    end
+
     private
 
     def bucket

--- a/app/services/ocsp_service.rb
+++ b/app/services/ocsp_service.rb
@@ -73,6 +73,6 @@ class OCSPService
 
   # :reek:UtilityFunction
   def process_http_response_body(body)
-    OpenSSL::OCSP::Response.new(body).basic if body.present?
+    OpenSSL::OCSP::Response.new(body) if body.present?
   end
 end

--- a/spec/models/ocsp_response_spec.rb
+++ b/spec/models/ocsp_response_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe OCSPResponse do
+  let(:ocsp_response) { described_class.new(service_request, response) }
+  let(:certificate) { Certificate.new(x509_cert) }
+
+  let(:certificate_error) do
+    TokenService.open(
+      certificate.send(:token_for_invalid_certificate, {})
+    )['error']
+  end
+
+  let(:certificate_store) { CertificateStore.instance }
+
+  let(:cert_collection) do
+    create_certificate_set(
+      root_count: 2,
+      intermediate_count: 2,
+      leaf_count: 2
+    )
+  end
+
+  let(:root_certs) { certificates_in_collection(cert_collection, :type, :root) }
+  let(:intermediate_certs) { certificates_in_collection(cert_collection, :type, :intermediate) }
+  let(:leaf_certs) { certificates_in_collection(cert_collection, :type, :leaf) }
+  let(:cert) { leaf_certs.first }
+
+  let(:root_cert) { root_certs.first.x509_cert }
+  let(:intermediate_cert) { intermediate_certs.first.x509_cert }
+  let(:leaf_cert) { leaf_certs.first.x509_cert }
+  let(:status) { :valid }
+  let(:valid_ocsp) { true }
+
+  let(:service_request) do
+    service = OCSPService.new(certificate)
+    service.send(:build_request)
+    service
+  end
+
+  let(:request_der) { service_request.request.to_der }
+
+  let(:response) do
+    OpenSSL::OCSP::Response.new(
+      create_ocsp_response(request_der, cert_collection, status, valid_ocsp)
+    )
+  end
+
+  let(:ca_file_path) { data_file_path('certs.pem') }
+
+  let(:ca_file_content) do
+    cert_collection.map { |info| info[:certificate] }.map(&:to_pem).join("\n\n")
+  end
+
+  let(:root_cert_key_ids) { root_certs.map(&:key_id) }
+  before(:each) do
+    allow(IO).to receive(:binread).with(ca_file_path).and_return(ca_file_content)
+    allow(Figaro.env).to receive(:trusted_ca_root_identifiers).and_return(
+      root_cert_key_ids.join(',')
+    )
+    certificate_store.clear_trusted_ca_root_identifiers
+    certificate_store.add_pem_file(ca_file_path)
+  end
+
+  context 'a leaf cert' do
+    let(:x509_cert) { leaf_cert }
+
+    describe 'to_pem' do
+      let(:pem) { ocsp_response.to_pem.split(/\n/) }
+
+      it 'has a preamble line' do
+        expect(pem).to include('----- BEGIN OCSP -----')
+      end
+
+      it 'has a postamble line' do
+        expect(pem).to include('----- END OCSP -----')
+      end
+    end
+
+    describe 'to_text' do
+      let(:text) { ocsp_response.to_text }
+
+      it 'has the subject certificate serial number' do
+        expect(text).to include("Serial: #{certificate.serial}")
+      end
+    end
+
+    describe '#logging_filename' do
+      it 'includes keys and serial number' do
+        expect(ocsp_response.logging_filename).to eq 'OCSP:' + [
+          certificate.key_id,
+          certificate.signing_key_id,
+          certificate.serial,
+        ].join('::')
+      end
+    end
+
+    describe '#logging_content' do
+      it 'includes the plaintext and the PEM form' do
+        expect(ocsp_response.logging_content).to eq [
+          certificate.to_pem,
+          ocsp_response.to_pem,
+          ocsp_response.to_text,
+        ].join("\n")
+      end
+    end
+  end
+
+  describe 'a cert that is revoked via ocsp' do
+    let(:status) { :revoked }
+    let(:x509_cert) { leaf_cert }
+    let(:ca_file_path) { data_file_path('certs.pem') }
+
+    let(:ca_file_content) do
+      cert_collection.map { |info| info[:certificate] }.map(&:to_pem).join("\n\n")
+    end
+
+    let(:root_cert_key_ids) { root_certs.map(&:key_id) }
+    before(:each) do
+      allow(IO).to receive(:binread).with(ca_file_path).and_return(ca_file_content)
+      allow(Figaro.env).to receive(:trusted_ca_root_identifiers).and_return(
+        root_cert_key_ids.join(',')
+      )
+      certificate_store.clear_trusted_ca_root_identifiers
+      certificate_store.add_pem_file(ca_file_path)
+    end
+
+    it { expect(ocsp_response.revoked?).to be_truthy }
+
+    describe 'but with a "malformed" ocsp request' do
+      let(:valid_ocsp) { false }
+
+      it { expect(ocsp_response.revoked?).to be_falsey }
+    end
+  end
+end

--- a/spec/services/certificate_logger_service_spec.rb
+++ b/spec/services/certificate_logger_service_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe CertificateLoggerService do
   let(:service) { described_class }
   let(:certificate) { Certificate.new(x509_cert) }
+  let(:ocsp_response) { OCSPResponse.new(service_request, response) }
 
   let(:cert_collection) do
     create_certificate_set(
@@ -20,38 +21,76 @@ RSpec.describe CertificateLoggerService do
 
   let(:x509_cert) { leaf_cert }
 
-  let(:ocsp_response) { false }
+  let(:ocsp_response_status) { false }
+  let(:status) { :valid }
+
   let(:ocsp_responder) do
     OpenStruct.new(
-      call: OpenStruct.new(revoked?: ocsp_response)
+      call: OpenStruct.new(revoked?: ocsp_response_status)
     )
   end
 
+  let(:service_request) do
+    service = OCSPService.new(certificate)
+    service.send(:build_request)
+    service
+  end
+
+  let(:request_der) { service_request.request.to_der }
+
+  let(:response) do
+    OpenSSL::OCSP::Response.new(
+      create_ocsp_response(request_der, cert_collection, status)
+    )
+  end
+
+  let(:certificate_store) { CertificateStore.instance }
+
+  let(:ca_file_path) { data_file_path('certs.pem') }
+
+  let(:ca_file_content) do
+    [root_cert, intermediate_cert].map { |cert| Certificate.new(cert) }.map(&:to_pem).join("\n\n")
+  end
+
+  let(:root_cert_key_id) { Certificate.new(root_cert).key_id }
   before(:each) do
-    allow(OCSPService).to receive(:new).and_return(ocsp_responder)
+    allow(IO).to receive(:binread).with(ca_file_path).and_return(ca_file_content)
+    allow(Figaro.env).to receive(:trusted_ca_root_identifiers).and_return(root_cert_key_id)
+    certificate_store.clear_trusted_ca_root_identifiers
+    certificate_store.add_pem_file(ca_file_path)
+    allow(OCSPService).to receive(:new).and_return(service_request)
   end
 
   after(:each) do
     service.instance_variable_set(:@bucket, nil)
   end
 
-  describe '#log_certificate' do
-    context 'with no bucket configured' do
-      before(:each) do
-        allow(Figaro.env).to receive(:client_cert_logger_s3_bucket_name) {}
-      end
+  context 'with no bucket configured' do
+    before(:each) do
+      allow(Figaro.env).to receive(:client_cert_logger_s3_bucket_name) {}
+    end
 
+    describe '#log_certificate' do
       it 'does nothing' do
         expect(Aws::S3::Resource).to_not receive(:new)
         service.log_certificate(certificate)
       end
     end
 
-    context 'with a bucket configured' do
-      before(:each) do
-        allow(Figaro.env).to receive(:client_cert_logger_s3_bucket_name) { 'cert_logging_bucket' }
+    describe '#log_ocsp_response' do
+      it 'does nothing' do
+        expect(Aws::S3::Resource).to_not receive(:new)
+        service.log_ocsp_response(ocsp_response)
       end
+    end
+  end
 
+  context 'with a bucket configured' do
+    before(:each) do
+      allow(Figaro.env).to receive(:client_cert_logger_s3_bucket_name) { 'cert_logging_bucket' }
+    end
+
+    describe '#log_certificate' do
       it 'puts the certificate info in the bucket' do
         allow(Aws::S3::Resource).to receive(:new) do
           resource = double
@@ -70,6 +109,28 @@ RSpec.describe CertificateLoggerService do
         end
 
         service.log_certificate(certificate)
+      end
+    end
+
+    describe '#log_ocsp_response' do
+      it 'puts the ocsp response info in the bucket' do
+        allow(Aws::S3::Resource).to receive(:new) do
+          resource = double
+          allow(resource).to receive(:bucket).with('cert_logging_bucket') do
+            bucket = double
+            allow(bucket).to receive(:object).with(ocsp_response.logging_filename) do
+              object = double
+              expect(object).to receive(:put).with(
+                body: ocsp_response.logging_content
+              ) {}
+              object
+            end
+            bucket
+          end
+          resource
+        end
+
+        service.log_ocsp_response(ocsp_response)
       end
     end
   end

--- a/spec/support/x509.rb
+++ b/spec/support/x509.rb
@@ -56,7 +56,9 @@ module X509Helpers
   end
 
   # :reek:ControlParameter
-  def create_ocsp_response(request_der, cert_collection, status_enum = :valid)
+  # :reek:BooleanParameter
+  # :reek:LongParameterList
+  def create_ocsp_response(request_der, cert_collection, status_enum = :valid, valid_ocsp = true)
     request = OpenSSL::OCSP::Request.new(request_der)
     status = OCSP_STATUS[status_enum]
 
@@ -72,7 +74,7 @@ module X509Helpers
       issuer = issuer_info[:certificate]
       signing_key = issuer_info[:key]
       basic_response.sign(issuer.x509_cert, signing_key, [])
-      OpenSSL::OCSP::Response.create(status, basic_response).to_der
+      OpenSSL::OCSP::Response.create(valid_ocsp ? 0 : 1, basic_response).to_der
     end.join('')
   end
 


### PR DESCRIPTION
**Why**: Some users are reporting that their PIV/CAC is coming back as
revoked even though they/we have reason to believe they aren't. We need
to log the OCSP responses so we can see what's causing the system to
mark the PIV/CAC cert as revoked.

**How**: If the OCSP response indicates that it is not successful OR
that the PIV/CAC cert is revoked, we drop the response along with some
textual content into the same S3 bucket into which we log unverifiable
certs.