### PR TITLE
[LG-880] Validate issuing certs on-demand

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -107,7 +107,7 @@ class Certificate
   def signature_verified?
     signing_cert = CertificateStore.instance[signing_key_id]
     UnrecognizedCertificateAuthority.find_or_create_for_certificate(self) unless signing_cert
-    signing_cert && verify(signing_cert.public_key)
+    signing_cert && verify(signing_cert.public_key) && signing_cert.valid?
   end
 
   def ca_capable?

--- a/config/initializers/certificate_store.rb
+++ b/config/initializers/certificate_store.rb
@@ -7,12 +7,4 @@ unless File.basename($PROGRAM_NAME) == 'rake' && ARGV.any? { |arg| arg.start_wit
       cert_store.add_pem_file(file)
     end
   end
-
-  cert_store.remove_untrusted_certificates
-
-  unless cert_store.all_certificates_valid?
-    raise 'Not all certificates in the certificate store can be trusted'
-  end
-
-  raise 'There are no trusted certificates available' if cert_store.empty? && Rails.env.production?
 end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -77,6 +77,75 @@ RSpec.describe Certificate do
     end
   end
 
+  describe '#signature_verified?' do
+    let(:x509_cert) { leaf_cert }
+
+    let(:ca_file_path) { data_file_path('certs.pem') }
+
+    let(:root_cert_key_ids) { root_certs.map(&:key_id) }
+    let(:intermediate_cert_key_ids) { intermediate_certs.map(&:key_id) }
+
+    let(:ca_file_content) do
+      cert_collection.map { |info| info[:certificate] }.map(&:to_pem).join("\n\n")
+    end
+
+    let(:cert_identifiers) do
+      mapping = {}
+      leaf_certs.each do |cert|
+        issuer = CertificateStore.instance[cert.signing_key_id]
+        certificate_id = OpenSSL::OCSP::CertificateId.new(
+          cert.x509_cert, issuer.x509_cert, OpenSSL::Digest::SHA1.new
+        )
+        mapping[certificate_id] = {
+          subject: cert,
+          issuer: issuer,
+        }
+      end
+      mapping
+    end
+
+    before(:each) do
+      allow(IO).to receive(:binread).with(ca_file_path).and_return(ca_file_content)
+      allow(Figaro.env).to receive(:trusted_ca_root_identifiers).and_return(
+        root_cert_key_ids.join(',')
+      )
+      certificate_store.clear_trusted_ca_root_identifiers
+      certificate_store.add_pem_file(ca_file_path)
+    end
+
+    context 'for an expired intermediate certificate' do
+      let(:cert_collection) do
+        create_certificate_set(
+          root_count: 2,
+          intermediate_count: 2,
+          leaf_count: 2,
+          intermediate_options: {
+            not_after: Time.zone.now - 1.day,
+            not_before: Time.zone.now - 1.week,
+          }
+        )
+      end
+
+      it 'has invalid intermediates' do
+        expect(intermediate_certs.any?(&:valid?)).to be_falsey
+      end
+
+      it 'is invalid' do
+        expect(certificate.signature_verified?).to be_falsey
+      end
+    end
+
+    context 'for a valid intermediate certificate' do
+      it 'has valid intermediates' do
+        expect(intermediate_certs.all?(&:valid?)).to be_truthy
+      end
+
+      it 'is valid' do
+        expect(certificate.signature_verified?).to be_truthy
+      end
+    end
+  end
+
   describe 'to_pem' do
     let(:pem) { certificate.to_pem.split(/\n/) }
     let(:x509_cert) { leaf_cert }

--- a/spec/support/x509.rb
+++ b/spec/support/x509.rb
@@ -219,10 +219,14 @@ module X509Helpers
     root_certs = []
     intermediate_certs = []
     leaf_certs = []
+    root_options = options[:root_options] || {}
+    intermediate_options = options[:intermediate_options] || {}
+    leaf_options = options[:leaf_options] || {}
     options[:root_count].times do |root_index|
       root, root_key = create_root_certificate(
         dn: "DC=com, DC=example, OU=ca, CN=Root #{root_index + 1}",
-        serial: root_index + 1
+        serial: root_index + 1,
+        **root_options
       )
       root_cert_id = OpenSSL::OCSP::CertificateId.new(
         root, root, OpenSSL::Digest::SHA1.new
@@ -244,7 +248,8 @@ module X509Helpers
           ].join(' '),
           serial: intermediate_index + 1,
           ca: root,
-          ca_key: root_key
+          ca_key: root_key,
+          **intermediate_options
         )
         intermediate_cert_id = OpenSSL::OCSP::CertificateId.new(
           intermediate, root, OpenSSL::Digest::SHA1.new
@@ -270,7 +275,7 @@ module X509Helpers
             serial: leaf_index + 1,
             ca: intermediate,
             ca_key: intermediate_key,
-            **(options[:leaf_options] || {})
+            **leaf_options
           )
           leaf_cert_id = OpenSSL::OCSP::CertificateId.new(
             leaf, intermediate, OpenSSL::Digest::SHA1.new


### PR DESCRIPTION
**Why**: Rather than validate them on startup, we do so
when we are presented with a certificate. This speeds up
startup and makes mid-sprint invalidation of intermediate
certs more timely.

**How**: We check the validity of the signing cert if the
signature of the issued cert is valid. We remove the startup
walk of certificates to remove invalid certificates.