### PR TITLE
Restore caching of OCSP revocations

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -30,8 +30,7 @@ class Certificate
     elsif ocsp_response.revoked?
       CertificateLoggerService.log_ocsp_response(ocsp_response)
       # save serial number as revoked
-      # temporarily not caching it while we investigate some reported wrong revocations via OCSP
-      # ocsp_response.authority&.certificate_revocations&.create!(serial: serial) if revoked_status
+      ocsp_response.authority&.certificate_revocations&.create!(serial: serial)
       true
     else
       false

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -17,24 +17,7 @@ class Certificate
   end
 
   def revoked?
-    Certificate.revocation_status?(self) { calculate_revocation_status }
-  end
-
-  # :reek:DuplicateMethodCall
-  # :reek:TooManyStatements
-  def calculate_revocation_status
-    ocsp_response = OCSPService.new(self).call
-    if !ocsp_response.successful?
-      CertificateLoggerService.log_ocsp_response(ocsp_response)
-      CertificateAuthority.revoked?(self)
-    elsif ocsp_response.revoked?
-      CertificateLoggerService.log_ocsp_response(ocsp_response)
-      # save serial number as revoked
-      ocsp_response.authority&.certificate_revocations&.create!(serial: serial)
-      true
-    else
-      false
-    end
+    Certificate.revocation_status?(self) { OCSPService.new(self).call.revoked? }
   end
 
   def self.revocation_status?(certificate, &block)

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe Certificate do
       certificate.revoked?
     end
 
-    xit 'adds the serial number to the list of revoked serials' do
+    it 'adds the serial number to the list of revoked serials' do
       expect { certificate.revoked? }.to change { CertificateRevocation.count }.by(1)
     end
 

--- a/spec/services/ocsp_service_spec.rb
+++ b/spec/services/ocsp_service_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe OCSPService do
   let(:leaf_certs) { certificates_in_collection(cert_collection, :type, :leaf) }
   let(:cert) { leaf_certs.first }
 
+  before(:each) do
+    allow(CertificateAuthority).to receive(:revoked?).and_return(:cached_status)
+  end
+
   describe 'OCSP response caching' do
     let(:ca_file_path) { data_file_path('certs.pem') }
 
@@ -203,16 +207,16 @@ RSpec.describe OCSPService do
     context 'with valid certs' do
       let(:status) { :valid }
 
-      it 'returns nil for a cert with a known ca' do
-        expect(ocsp_service.call.revoked?).to be_nil
+      it 'returns the cached status for a cert with a known ca' do
+        expect(ocsp_service.call.revoked?).to eq :cached_status
       end
     end
 
     context 'with invalid certs' do
       let(:status) { :revoked }
 
-      it 'returns nil for a cert with a known ca' do
-        expect(ocsp_service.call.revoked?).to be_nil
+      it 'returns the cached status for a cert with a known ca' do
+        expect(ocsp_service.call.revoked?).to eq :cached_status
       end
     end
   end
@@ -249,16 +253,16 @@ RSpec.describe OCSPService do
     context 'with valid certs' do
       let(:status) { :valid }
 
-      it 'returns nil for a cert with a known ca' do
-        expect(ocsp_service.call.revoked?).to be_nil
+      it 'returns the cached status for a cert with a known ca' do
+        expect(ocsp_service.call.revoked?).to eq :cached_status
       end
     end
 
     context 'with invalid certs' do
       let(:status) { :revoked }
 
-      it 'returns nil for a cert with a known ca' do
-        expect(ocsp_service.call.revoked?).to be_nil
+      it 'returns the cached status for a cert with a known ca' do
+        expect(ocsp_service.call.revoked?).to eq :cached_status
       end
     end
   end
@@ -291,8 +295,8 @@ RSpec.describe OCSPService do
         end
       end
 
-      it 'returns nil' do
-        expect(ocsp_service.call.revoked?).to be_nil
+      it 'returns the cached status' do
+        expect(ocsp_service.call.revoked?).to eq :cached_status
       end
     end
 
@@ -324,16 +328,16 @@ RSpec.describe OCSPService do
       context 'nonce' do
         let(:variant) { :nonce }
 
-        it 'returns nil' do
-          expect(ocsp_service.call.revoked?).to be_nil
+        it 'returns the cached status' do
+          expect(ocsp_service.call.revoked?).to eq :cached_status
         end
       end
 
       context 'signing_key' do
         let(:variant) { :signing_key }
 
-        it 'returns nil' do
-          expect(ocsp_service.call.revoked?).to be_nil
+        it 'returns the cached status' do
+          expect(ocsp_service.call.revoked?).to eq :cached_status
         end
       end
     end


### PR DESCRIPTION
**Why**: We cache the responses in case we can't connect
to the OCSP server at the time a cert is presented again.

**How**: Uncomment the line that does the caching. Of course, linting
caused a lot more changes.