### PR TITLE
Ensure finite is less than infinite

### DIFF
--- a/app/models/finite_policy_mapping_depth.rb
+++ b/app/models/finite_policy_mapping_depth.rb
@@ -16,7 +16,11 @@ class FinitePolicyMappingDepth
 
   # :reek:FeatureEnvy
   def <=>(other)
-    value <=> other.value
+    if other.any?
+      -1
+    else
+      value <=> other.value
+    end
   end
 
   def -(other)

--- a/spec/models/finite_policy_mapping_depth_spec.rb
+++ b/spec/models/finite_policy_mapping_depth_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe FinitePolicyMappingDepth do
+  it 'is always less than an infinite policy mapping depth' do
+    expect(FinitePolicyMappingDepth.new(1) <=> InfinitePolicyMappingDepth.new).to eq(-1)
+  end
+end


### PR DESCRIPTION
**Why**: Sometimes, intermediate certificates can have an
"infinite" policy mapping depth. This means that any finite
limit overrules that certificate's policy on policy mappings.

**How**: Make sure that if the finite depth is compared against
an infinite depth, the comparison doesn't throw an error.