### PR TITLE
Fix parsing of multiline authorityKeyIdentifier.

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -98,7 +98,8 @@ class Certificate
   end
 
   def signing_key_id
-    get_extension('authorityKeyIdentifier')&.sub(/^keyid:/, '')&.chomp&.upcase
+    get_extension('authorityKeyIdentifier')&.lines&.grep(/\Akeyid:/)&.first
+                                           &.sub(/\Akeyid:/, '')&.chomp&.upcase
   end
 
   def crl_http_url

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -235,6 +235,22 @@ RSpec.describe Certificate do
         ].join("\n\n")
       end
     end
+
+    describe '#signing_key_id' do
+      it 'handles multiline authorityKeyIdentifier' do
+        # stub multiline aKI
+        expect(certificate).to receive(:get_extension).with('authorityKeyIdentifier').and_return(
+          <<~CERT
+            keyid:cf:ab:b1:cf:b3:eb:28:e2:e0:c7:24:75:72:3b:f5:b6:31:18:77:6f
+            DirName:/CN=my test CA
+            serial:89:20:39:72:B8:50:56:5E
+          CERT
+        )
+        expect(certificate.signing_key_id).to eq(
+          'CF:AB:B1:CF:B3:EB:28:E2:E0:C7:24:75:72:3B:F5:B6:31:18:77:6F'
+        )
+      end
+    end
   end
 
   describe 'a cert with no trusted cert in cert store' do


### PR DESCRIPTION
The X.509 v3 authorityKeyIdentifier may contain a sequence of multiple
string values. The key ID parsing should only return the line containing
the keyid.

For example:

    "keyid:CF:AB:B1:CF:B3:EB:28:E2:E0:C7:24:75:72:3B:F5:B6:31:18:77:6F\nDirName:/CN=my test CA\nserial:89:20:39:72:B8:50:56:5E\n"


Illustrated by test failure:

```
Failures:

  1) Certificate a leaf cert #signing_key_id handles multiline authorityKeyIdentifier
     Failure/Error:
       expect(certificate.signing_key_id).to eq(
         'CF:AB:B1:CF:B3:EB:28:E2:E0:C7:24:75:72:3B:F5:B6:31:18:77:6F'
       )
     
       expected: "CF:AB:B1:CF:B3:EB:28:E2:E0:C7:24:75:72:3B:F5:B6:31:18:77:6F"
            got: "CF:AB:B1:CF:B3:EB:28:E2:E0:C7:24:75:72:3B:F5:B6:31:18:77:6F\nDIRNAME:/CN=MY TEST CA\nSERIAL:89:20:39:72:B8:50:56:5E"
     
       (compared using ==)
     
       Diff:
       @@ -1,2 +1,4 @@
        CF:AB:B1:CF:B3:EB:28:E2:E0:C7:24:75:72:3B:F5:B6:31:18:77:6F
       +DIRNAME:/CN=MY TEST CA
       +SERIAL:89:20:39:72:B8:50:56:5E
       
     # ./spec/models/certificate_spec.rb:249:in `block (4 levels) in <top (required)>'
```