### PR TITLE
Change the identifier for New Relic

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,6 +1,6 @@
 production:
   agent_enabled: true
-  app_name: <%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>
+  app_name: pki-rails.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>
   audit_log:
     enabled: false
   error_collector:

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,6 +1,6 @@
 production:
   agent_enabled: true
-  app_name: pki-rails.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>
+  app_name: pivcac.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>
   audit_log:
     enabled: false
   error_collector:


### PR DESCRIPTION
**Why**: We need to distinguish between piv/cac and idp servers.

**How**: Prepend the identifier with `pki-rails.`