### PR TITLE
Optionally pull in extra certs from a fixed path in S3 at activate time

### DIFF
--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -42,7 +42,9 @@ module Deploy
                            File.join(root,
                                      'config/certs/extra_pivcac_certs.pem'))
       # If the file doesn't exist that's fine. This step is optional.
-      rescue Aws::S3::Errors::NotFound; end
+      rescue Aws::S3::Errors::NotFound
+        logger.info('extra_pivcac_certs.pem is not in S3 but that is okay.')
+      end
     end
 
     def default_logger

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -42,7 +42,7 @@ module Deploy
                            File.join(root,
                                      'config/certs/extra_pivcac_certs.pem'))
       # If the file doesn't exist that's fine. This step is optional.
-      rescue Aws::S3::Errors::NotFound
+      rescue Aws::S3::Errors::NoSuchKey
         logger.info('extra_pivcac_certs.pem is not in S3 but that is okay.')
       end
     end

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -37,8 +37,7 @@ module Deploy
           logger: logger,
           s3_client: s3_client,
         ).download_configs('/%<env>s/extra_pivcac_certs.pem')
-      rescue rescue Aws::S3::Errors::NotFound
-      end
+      rescue; end
     end
 
     def default_logger

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -39,7 +39,8 @@ module Deploy
           logger: logger,
           s3_client: s3_client,
         ).download_configs('/%<env>s/extra_pivcac_certs.pem' =>
-                           'config/certs/extra_pivcac_certs.pem')
+                           File.join(root,
+                                     'config/certs/extra_pivcac_certs.pem'))
       # If the file doesn't exist that's fine. This step is optional.
       rescue Aws::S3::Errors::NotFound; end
     end

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -34,8 +34,6 @@ module Deploy
       begin
         LoginGov::Hostdata::S3.new(
           bucket: "login-gov.secrets.#{aws_account_id}-#{aws_region}",
-          env: nil,
-          region: aws_region,
           logger: logger,
           s3_client: s3_client,
         ).download_configs('/%<env>s/extra_pivcac_certs.pem' => 'config/certs/extra_pivcac_certs.pem')

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -38,7 +38,9 @@ module Deploy
           region: aws_region,
           logger: logger,
           s3_client: s3_client,
-        ).download_configs('/%<env>s/extra_pivcac_certs.pem' => 'config/certs/extra_pivcac_certs.pem')
+        ).download_configs('/%<env>s/extra_pivcac_certs.pem' =>
+                           'config/certs/extra_pivcac_certs.pem')
+      # If the file doesn't exist that's fine. This step is optional.
       rescue Aws::S3::Errors::NotFound; end
     end
 

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -38,8 +38,8 @@ module Deploy
           region: aws_region,
           logger: logger,
           s3_client: s3_client,
-        ).download_configs('/%<env>s/extra_pivcac_certs.pem')
-      rescue; end
+        ).download_configs('/%<env>s/extra_pivcac_certs.pem' => 'config/certs/extra_pivcac_certs.pem')
+      rescue Aws::S3::Errors::NotFound; end
     end
 
     def default_logger

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -34,7 +34,7 @@ module Deploy
       begin
         LoginGov::Hostdata::S3.new(
           bucket: "login-gov.secrets.#{aws_account_id}-#{aws_region}",
-          env: env,
+          env: LoginGov::Hostdata.env,
           region: aws_region,
           logger: logger,
           s3_client: s3_client,

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -27,13 +27,15 @@ module Deploy
     private
 
     def download_extra_certs_from_s3
-      ec2_region = ec2_data.region
+      ec2_data = LoginGov::Hostdata::EC2.load
+      aws_region = ec2_data.region
+      aws_account_id = ec2_data.account_id
 
       begin
         LoginGov::Hostdata::S3.new(
-          bucket: "login-gov.secrets.#{ec2_data.account_id}-#{ec2_region}",
+          bucket: "login-gov.secrets.#{aws_account_id}-#{aws_region}",
           env: nil,
-          region: ec2_region,
+          region: aws_region,
           logger: logger,
           s3_client: s3_client,
         ).download_configs('/%<env>s/extra_pivcac_certs.pem')

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -34,6 +34,8 @@ module Deploy
       begin
         LoginGov::Hostdata::S3.new(
           bucket: "login-gov.secrets.#{aws_account_id}-#{aws_region}",
+          env: env,
+          region: aws_region,
           logger: logger,
           s3_client: s3_client,
         ).download_configs('/%<env>s/extra_pivcac_certs.pem' => 'config/certs/extra_pivcac_certs.pem')

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -110,4 +110,21 @@ describe Deploy::Activate do
       expect { subject.run }.to raise_error(Net::OpenTimeout)
     end
   end
+
+  let(:s3_empty) { LoginGov::Hostdata::FakeS3Client.new }
+  let(:notfound_subject) {
+    Deploy::Activate.new(logger: logger, s3_client: s3_empty) }
+  context 'in a deployed production environment with no extra cert bundle' do
+    before do
+      stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+        to_return(body: {
+          'region' => 'us-west-1',
+          'accountId' => '12345',
+        }.to_json)
+    end
+
+    it 'downloads configs from s3' do
+      notfound_subject.send(:download_extra_certs_from_s3)
+    end
+  end
 end

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -40,6 +40,12 @@ describe Deploy::Activate do
         body: application_yml
       )
 
+      s3_client.put_object(
+        bucket: 'login-gov.secrets.12345-us-west-1',
+        key: '/int/extra_pivcac_certs.pem',
+        body: "fake cert file"
+      )
+
       FileUtils.mkdir_p('/etc/login.gov/info')
       File.open('/etc/login.gov/info/env', 'w') { |file| file.puts 'int' }
     end
@@ -55,6 +61,8 @@ describe Deploy::Activate do
       subject.run
 
       expect(File.exist?(File.join(config_dir, 'application.yml'))).to eq(true)
+      expect(File.exist?(File.join(config_dir, 'certs',
+                                   'extra_pivcac_certs.pem'))).to eq(true)
     end
 
     it 'merges the application.yml from s3 over the application.yml.example' do

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -125,7 +125,7 @@ describe Deploy::Activate do
 
     it 'downloads configs from s3' do
       allow(s3_empty).to receive(:get_object) do |arg1|
-        raise Aws::S3::Errors::NotFound.new("an error", "for testing")
+        raise Aws::S3::Errors::NoSuchKey.new("an error", "for testing")
       end
       notfound_subject.send(:download_extra_certs_from_s3)
     end

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -124,6 +124,11 @@ describe Deploy::Activate do
     end
 
     it 'downloads configs from s3' do
+      allow(s3_empty).to receive(:get_object) do |arg1|
+        puts "this is our broken get_object"
+        err_obj = Aws::S3::Errors::NotFound.new("this is an error", "what is")
+        raise err_obj
+      end
       notfound_subject.send(:download_extra_certs_from_s3)
     end
   end

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -125,9 +125,7 @@ describe Deploy::Activate do
 
     it 'downloads configs from s3' do
       allow(s3_empty).to receive(:get_object) do |arg1|
-        puts "this is our broken get_object"
-        err_obj = Aws::S3::Errors::NotFound.new("this is an error", "what is")
-        raise err_obj
+        raise Aws::S3::Errors::NotFound.new("an error", "for testing")
       end
       notfound_subject.send(:download_extra_certs_from_s3)
     end


### PR DESCRIPTION
This way we can stop doing this from Chef.