### PR TITLE
LG-1953 Log missing nonce error instead of raising

### DIFF
--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -8,6 +8,9 @@ class IdentifyController < ApplicationController
 
   delegate :logger, to: Rails
 
+  rescue_from URI::InvalidURIError, with: :render_bad_referrer_error
+  rescue_from ActionController::ParameterMissing, with: :render_missing_param_error
+
   def create
     if referrer
       # given a valid certificate from the client, return a token
@@ -18,8 +21,6 @@ class IdentifyController < ApplicationController
     else
       render_bad_request('No referrer')
     end
-  rescue URI::InvalidURIError
-    render_bad_request('Bad referrer')
   end
 
   private
@@ -27,6 +28,14 @@ class IdentifyController < ApplicationController
   def render_bad_request(reason)
     logger.warn("#{reason}, returning Bad Request.")
     render plain: 'Invalid request', status: :bad_request
+  end
+
+  def render_bad_referrer_error
+    render_bad_request('Bad referrer')
+  end
+
+  def render_missing_param_error(exception)
+    render_bad_request("Missing #{exception.param} param")
   end
 
   # :reek:UtilityFunction

--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -258,6 +258,13 @@ RSpec.describe IdentifyController, type: :controller do
             expect(token_contents['nonce']).to eq '123'
           end
         end
+
+        context 'when the nonce param is missing' do
+          it 'returns a bad request' do
+            get :create, params: {}
+            expect(response).to have_http_status(:bad_request)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**Why**: To reduce the noise in our error reporting that is caused by people hitting the PIV/CAC server w/o coming from the IdP (e.g. pen testers)