### PR TITLE
run piv_cac locally with idp

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ PIV/CAC support for login.gov.
   $ make run
   ```
 
-**TODO** Instructions for setting up NGinx to handle TLS/SSL.
-
 Before making any commits, you'll also need to run `overcommit --sign.`
 This verifies that the commit hooks defined in our `.overcommit.yml` file are
 the ones we expect. Each change to the `.overcommit.yml` file, including the initial install
@@ -73,10 +71,84 @@ restart the server. See the [rack_mini_profiler] gem for more details.
 [Laptop]: https://github.com/18F/laptop
 [rack_mini_profiler]: https://github.com/MiniProfiler/rack-mini-profiler
 
-### Viewing the app locally
+### Running the app locally with the IDP
 
-Once it is up and running, the app will be accessible at
-`http://localhost:3001/` by default.
+#### Create a root SSL certificate
+
+1. From the console insure you are at the root of the /identity_pki/ directory.
+
+2. Generate a RSA-2048 key - rootCA.key
+
+  ```
+  openssl genrsa -des3 -out rootCA.key 2048
+  ```
+
+3. Create a new Root SSL certificate - rootCA.pem
+
+  ```
+  openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.pem
+  ```
+
+#### Trust the root SSL certificate
+
+1. Open Keychain Access on your Mac and go to the Certificates category in your System keychain.
+
+2. Import the rootCA.pem using File > Import Items.
+
+3. Double click the imported certificate and change the “When using this certificate:” dropdown to Always Trust in the Trust section.
+
+#### Create a localhost SSL certificate
+
+1. Create a new file named server.csr.cnf
+
+2. Copy and past the contents below into the server.csr.cnf file to create an OpenSSL configuration.
+
+  ```
+  [req]
+  default_bits = 2048
+  prompt = no
+  default_md = sha256
+  distinguished_name = dn
+
+  [dn]
+  C=US
+  ST=RandomState
+  L=RandomCity
+  O=RandomOrganization
+  OU=RandomOrganizationUnit
+  emailAddress=hello@example.com
+  CN = localhost
+  ```
+
+3. Create a new file named v3.ext
+
+4. Copy and past the contents below into the v3.ext file to create a X509 v3 certificate.
+
+  ```
+  authorityKeyIdentifier=keyid,issuer
+  basicConstraints=CA:FALSE
+  keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+  subjectAltName = @alt_names
+
+  [alt_names]
+  DNS.1 = localhost
+  ```
+
+5. Run the following command to create server.key for localhost.
+  ```
+  openssl req -new -sha256 -nodes -out server.csr -newkey rsa:2048 -keyout server.key -config <( cat server.csr.cnf )
+  ```
+
+6. Run the following command to create a certificate signing request for localhost.
+  ```
+  openssl x509 -req -in server.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out server.crt -days 500 -sha256 -extfile v3.ext
+  ```
+
+#### Running the PKI app locally
+
+  ```
+  bundle exec thin start -p 8443 --ssl --ssl-key-file server.key --ssl-cert-file server.crt
+  ```
 
 ### Certificate Authority Management
 

--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -50,9 +50,9 @@ class IdentifyController < ApplicationController
     CGI.escape(token)
   end
 
+  # :reek:DuplicateMethodCall
   def client_cert
-    headers = request.headers
-    cert_pem = headers[CERT_HEADER] || headers.env['rack.peer_cert']
+    cert_pem = request.headers[CERT_HEADER] || request.headers.env['rack.peer_cert']
     return unless cert_pem
     if Figaro.env.client_cert_escaped == 'true'
       CGI.unescape(cert_pem)

--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -51,7 +51,7 @@ class IdentifyController < ApplicationController
   end
 
   def client_cert
-    cert_pem = request.headers[CERT_HEADER]
+    cert_pem = request.headers[CERT_HEADER] || request.headers.env['rack.peer_cert']
     return unless cert_pem
     if Figaro.env.client_cert_escaped == 'true'
       CGI.unescape(cert_pem)

--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -51,7 +51,8 @@ class IdentifyController < ApplicationController
   end
 
   def client_cert
-    cert_pem = request.headers[CERT_HEADER] || request.headers.env['rack.peer_cert']
+    headers = request.headers
+    cert_pem = headers[CERT_HEADER] || headers.env['rack.peer_cert']
     return unless cert_pem
     if Figaro.env.client_cert_escaped == 'true'
       CGI.unescape(cert_pem)

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -39,7 +39,7 @@ required_policies: |
 
 development:
   aws_region: 'us-east-1'
-  client_cert_escaped: 'true'
+  client_cert_escaped: 'false'
   database_name: 'identity_pki_dev'
   identity_idp_host: 'localhost'
   nonce_bloom_filter_server: 'redis://localhost:6379/2'


### PR DESCRIPTION
Why:
Provide instructions on how to run the piv_cac server locally with the idp.