### PR TITLE
Use ruby 2.5 and bundler 1.17.x by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: circleci/ruby:2.3-node-browsers
+      - image: circleci/ruby:2.5-node-browsers
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: c88a6f4af1fbf80e0fc9a5593ebff124b2f940645b1eacb5adb681522bbf650e

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby '~> 2.3.5'
+ruby '~> 2.5.7'
 
 gem 'rails', '~> 5.2', '>= 5.2.2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1152,7 +1152,7 @@ DEPENDENCIES
   zonebie
 
 RUBY VERSION
-   ruby 2.3.7p456
+   ruby 2.5.7p206
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
Fixes part of https://github.com/18F/identity-devops/issues/1951

Sets default ruby to `2.5.7`