### PR TITLE
Clear the OCSP response cache in the identify controller

### DIFF
--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe IdentifyController, type: :controller do
 
   before(:each) do
     Certificate.clear_revocation_cache
+    OCSPService.clear_ocsp_response_cache
   end
 
   describe 'GET /' do

--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -230,7 +230,8 @@ RSpec.describe IdentifyController, type: :controller do
 
         describe 'with a revoked certificate' do
           before(:each) do
-            allow_any_instance_of(OCSPService).to receive(:make_http_request).and_return(nil)
+            stub_request(:post, 'http://ocsp.example.com/').
+              to_return(status: 400, body: '', headers: {})
           end
 
           it 'returns a token as revoked' do
@@ -254,7 +255,7 @@ RSpec.describe IdentifyController, type: :controller do
 
         describe 'with a certificate timeout' do
           before(:each) do
-            allow_any_instance_of(OCSPService).to receive(:make_http_request).and_raise(Timeout::Error)
+            stub_request(:post, 'http://ocsp.example.com/').to_timeout
           end
 
           it 'returns a token as timeout' do
@@ -277,7 +278,8 @@ RSpec.describe IdentifyController, type: :controller do
 
         describe 'with a certificate ocsp error' do
           before(:each) do
-            allow_any_instance_of(OCSPService).to receive(:make_http_request).and_raise(OpenSSL::OCSP::OCSPError)
+            stub_request(:post, 'http://ocsp.example.com/').
+              to_return(status: 200, body: 'not-a-valid-cert', headers: {})
           end
 
           it 'returns a token as ocsp error' do


### PR DESCRIPTION
**Why**: The OCSP response cache saves the OCSP responses between rspec examples. This makes the specs flaky because the response from previous tests is cached.

This commit also replaces mocks that raise errors with webmocks to give us deeper test coverage (thanks @zachmargolis)