### PR TITLE
Allow a redirect URI param and use that to redirect back to the IdP

### DIFF
--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -77,7 +77,7 @@ class IdentifyController < ApplicationController
 
   def referrer
     @referrer ||= begin
-      value = request.headers[REFERER_HEADER]
+      value = params[:redirect_uri] || request.headers[REFERER_HEADER]
       if value
         value = URI(value)
         value.query = ''


### PR DESCRIPTION
**Why**: Newer versions of Chrome and Edge on Windows 10 are not sending us a request with a referrer header