### PR TITLE
LG-2623 Better logging for PIV/CAC errors

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -214,6 +214,6 @@ class Certificate
     reason = validate_cert
 
     Rails.logger.warn("Certificate invalid: #{reason}")
-    TokenService.box(extra.merge(error: "certificate.#{reason}|#{key_id}"))
+    TokenService.box(extra.merge(error: "certificate.#{reason}", key_id: key_id))
   end
 end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -214,6 +214,6 @@ class Certificate
     reason = validate_cert
 
     Rails.logger.warn("Certificate invalid: #{reason}")
-    TokenService.box(extra.merge(error: "certificate.#{reason}"))
+    TokenService.box(extra.merge(error: "certificate.#{reason}|#{key_id}"))
   end
 end

--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to eq 'certificate.expired'
+            expect(token_contents['error']).to start_with('certificate.expired|')
             expect(token_contents['nonce']).to eq '123'
           end
         end
@@ -264,7 +264,7 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to eq 'certificate.revoked'
+            expect(token_contents['error']).to start_with('certificate.revoked|')
             expect(token_contents['nonce']).to eq '123'
           end
         end
@@ -287,7 +287,7 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to eq 'certificate.timeout'
+            expect(token_contents['error']).to start_with('certificate.timeout|')
             expect(token_contents['nonce']).to eq '123'
           end
         end
@@ -311,7 +311,7 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to eq 'certificate.ocsp_error'
+            expect(token_contents['error']).to start_with('certificate.ocsp_error|')
             expect(token_contents['nonce']).to eq '123'
           end
         end
@@ -349,7 +349,7 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to eq 'certificate.unverified'
+            expect(token_contents['error']).to start_with('certificate.unverified|')
             expect(token_contents['nonce']).to eq '123'
           end
         end

--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -239,7 +239,8 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to start_with('certificate.expired|')
+            expect(token_contents['error']).to eq 'certificate.expired'
+            expect(token_contents['key_id']).to be_present
             expect(token_contents['nonce']).to eq '123'
           end
         end
@@ -264,7 +265,8 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to start_with('certificate.revoked|')
+            expect(token_contents['error']).to eq 'certificate.revoked'
+            expect(token_contents['key_id']).to be_present
             expect(token_contents['nonce']).to eq '123'
           end
         end
@@ -287,7 +289,8 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to start_with('certificate.timeout|')
+            expect(token_contents['error']).to eq 'certificate.timeout'
+            expect(token_contents['key_id']).to be_present
             expect(token_contents['nonce']).to eq '123'
           end
         end
@@ -311,7 +314,8 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to start_with('certificate.ocsp_error|')
+            expect(token_contents['error']).to eq 'certificate.ocsp_error'
+            expect(token_contents['key_id']).to be_present
             expect(token_contents['nonce']).to eq '123'
           end
         end
@@ -349,7 +353,8 @@ RSpec.describe IdentifyController, type: :controller do
             expect(response.has_header?('Location')).to be_truthy
             expect(token).to be_truthy
 
-            expect(token_contents['error']).to start_with('certificate.unverified|')
+            expect(token_contents['error']).to eq 'certificate.unverified'
+            expect(token_contents['key_id']).to be_present
             expect(token_contents['nonce']).to eq '123'
           end
         end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Certificate do
     it { expect(certificate.ca_capable?).to be_truthy }
     it { expect(certificate.self_signed?).to be_truthy }
     it { expect(certificate.valid?).to be_falsey }
-    it { expect(certificate_error).to eq 'certificate.self-signed cert' }
+    it { expect(certificate_error).to start_with('certificate.self-signed cert|') }
   end
 
   describe 'a leaf cert' do

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Certificate do
     it { expect(certificate.ca_capable?).to be_truthy }
     it { expect(certificate.self_signed?).to be_truthy }
     it { expect(certificate.valid?).to be_falsey }
-    it { expect(certificate_error).to start_with('certificate.self-signed cert|') }
+    it { expect(certificate_error).to eq 'certificate.self-signed cert' }
   end
 
   describe 'a leaf cert' do


### PR DESCRIPTION
**Why**: To more easily track cert errors
