### PR TITLE
LG-175: Dockerize for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@
 
 *.DS_Store
 
+/postgres-data
+
 # Ignore the files generated during setup
 /config/local-certs/rootCA.key
 /config/local-certs/rootCA.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Use the official Ruby image because the Rails images have been deprecated
+FROM ruby:2.6
+
+# Enable https
+RUN apt-get update
+RUN apt-get install -y apt-transport-https
+
+# Install Postgres client
+RUN apt-get install -y --no-install-recommends postgresql-client
+RUN rm -rf /var/lib/apt/lists/*
+
+# Everything happens here from now on   
+WORKDIR /pivcac
+
+# Simple Gem cache.  Success here creates a new layer in the image.
+COPY Gemfile .
+COPY Gemfile.lock .
+RUN gem install bundler --conservative
+RUN bundle install --without deploy production
+
+# Copy everything else over
+COPY . .
+
+# Up to this point we've been root, change to a lower priv. user
+RUN groupadd -r appuser
+RUN useradd --system --create-home --gid appuser appuser
+RUN chown -R appuser.appuser /pivcac
+USER appuser
+
+EXPOSE 8443
+CMD ["thin", "start", "-p", "8443", "--ssl", "--ssl-key-file", "config/local-certs/server.key", "--ssl-cert-file", "config/local-certs/server.crt"]

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ setup $(CONFIG): config/application.yml.example
 fast_setup:
 	bin/fast_setup
 
+docker_setup:
+	bin/docker_setup
+
 check: lint test
 
 lint:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ Most of the root certificate management is handled by `bin/setup` but there are 
 
 2. Open Keychain Access and delete the certificate named "**identity-pki Development Certificate**"
 
+#### Using Docker Locally
+
+1. Download, install, and launch [Docker](https://www.docker.com/products/docker-desktop).
+
+1. Build the Docker containers: `docker-compose build`
+
+1. Run `make docker_setup` to copy configuration files and bootstrap the database.
+
+1. Start the Docker containers `docker-compose up` and `open https://localhost:8443` (If you see an SSL error, check [Trust the root SSL certificate](#trust-the-root-ssl-certificate) instructions)
+
+
 ### Certificate Authority Management
 
 The PIV/CAC service relies on having all of the certificate authorities (issuing

--- a/bin/docker_setup
+++ b/bin/docker_setup
@@ -41,4 +41,7 @@ Dir.chdir APP_ROOT do
   run "docker-compose run --rm web rake db:environment:set"
   run "docker-compose run --rm web rake db:reset"
   run "docker-compose run --rm web rake db:environment:set"
+
+  puts "== Create tests database =="
+  run "docker-compose run --rm web rake db:create RAILS_ENV=test"
 end

--- a/bin/docker_setup
+++ b/bin/docker_setup
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path("../../",  __FILE__)
+
+def run(command)
+  abort "command failed (#{$?}): #{command}" unless system command
+end
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+Dir.chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file:
+
+  puts %q[
+   _             _
+  | |           (_)
+  | | ___   __ _ _ _ __    __ _  _____   __
+  | |/ _ \ / _` | | '_ \  / _` |/ _ \ \ / /
+  | | (_) | (_| | | | | || (_| | (_) \ V /
+  |_|\___/ \__, |_|_| |_(_)__, |\___/ \_/
+            __/ |          __/ |
+           |___/          |___/
+  ]
+
+  # This file is intended to run after `docker-compose up`
+  #  it runs commands that won't work at build time and therefore must be runuted at runtime.
+
+  puts '== Setting up certificates =='
+  Dir.chdir('config/local-certs') do
+    system! 'make'
+  end
+
+  puts "== Creating and migrating dev database =="
+  run "docker-compose run --rm web rake db:create"
+  # The following pattern prevents a database reset from happening in prod.
+  run "docker-compose run --rm web rake db:environment:set"
+  run "docker-compose run --rm web rake db:reset"
+  run "docker-compose run --rm web rake db:environment:set"
+end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -54,6 +54,8 @@ development:
   database_host: ''
   database_password: ''
   database_username: ''
+  database_statement_timeout: '2500'
+  database_timeout: '5000'
   secret_key_base: ''
   certificate_store_directory: 'config/certs'
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,6 +10,7 @@ defaults: &defaults
   pool: 5
   <<: *postgresql
   reconnect: true
+  timeout: <%= (Figaro.env.database_timeout || 5000).to_i %> # ms
   connect_timeout: 2
   keepalives_idle: 10
   keepalives_interval: 10
@@ -17,7 +18,7 @@ defaults: &defaults
   checkout_timeout: 5
   reaping_frequency: 10
   variables:
-    statement_timeout: 2500 # ms
+    statement_timeout: <%= (Figaro.env.database_statement_timeout || 2500).to_i %> # ms
 
 development:
   <<: *defaults

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  web:
+    build: .
+    volumes:
+      - .:/pivcac
+    ports:
+      - "8443:8443"
+    environment:
+      DATABASE_URL: "postgres://postgres@db"
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
+      nonce_bloom_filter_server: "redis://redis:6379"
+      # Set database timeouts to 30 seconds
+      database_timeout: '30000'
+      database_statement_timeout: '30000'
+      DOCKER_DB_HOST: 'db'
+      DOCKER_DB_USER: 'postgres'
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+  redis:
+    image: redis


### PR DESCRIPTION
I basically copy-pasted what Clint did in IDP to do this

To make sure it works, I ran the rest suite:

```
docker-compose exec web bundle exec rspec
```

I got the server to locally work with my PIV with PKI inside the docker container, but the IDP was **outside** the container ☹️ 

- The IDP backend makes a POST to the PKI backend, and that failed when IDP was inside a Docker container, so I think we need to poke a hole in the IDP container at 8443 so it can get to the PKI Docker container? That's beyond my expertise (and outside this repo) so I consider this good enough for now?

Would love to hear from others who give this a shot!