### PR TITLE
Add logging around OCSP requests

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -28,3 +28,4 @@ directories:
 exclude_paths:
   - db/migrate
   - lib/deploy
+  - app/services/ocsp_service.rb


### PR DESCRIPTION
Example log output:

```
2020-04-22T23:38:02+02:00 | oscp: cache miss, http://ocsp.example.com/ | ocsp_service.rb:22
2020-04-22T23:38:02+02:00 | oscp: pre-request http://ocsp.example.com/ | ocsp_service.rb:102
2020-04-22T23:38:02+02:00 | oscp: post-request http://ocsp.example.com/ | ocsp_service.rb:104
2020-04-22T23:38:02+02:00 | oscp: 2XX response received | ocsp_service.rb:78
2020-04-22T23:38:02+02:00 | oscp: cache miss, http://ocsp.example.com/ | ocsp_service.rb:22
2020-04-22T23:38:02+02:00 | oscp: pre-request http://ocsp.example.com/ | ocsp_service.rb:102
2020-04-22T23:38:02+02:00 | oscp: post-request http://ocsp.example.com/ | ocsp_service.rb:104
2020-04-22T23:38:02+02:00 | oscp: 2XX response received | ocsp_service.rb:78
```
