### PR TITLE
Update newrelic to use gov endpoint

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,6 +1,7 @@
 production:
   agent_enabled: true
   app_name: pivcac.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>
+  host: gov-collector.newrelic.com
   audit_log:
     enabled: false
   error_collector:


### PR DESCRIPTION
The PIVCAC uses a static `newrelic.yml` file instead of the Chef created one that the IdP uses.

This updates the PIVCAC to use the new Fed NewRelic endpoint. 

**This needs to be deployed before `identity-devops` `v128` is deployed to Production.**

