### PR TITLE
Update .gitignore to allow .pem files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 /config/application.yml
 /config/certs/*.p7c
 /config/certs/*.cer
-/config/certs/*.pem
 
 # Ignore the default SQLite database.
 /db/*.sqlite3


### PR DESCRIPTION
**Why**: The files we check in are public keys, it's OK for them
to be in source control