### PR TITLE
Add check for certs expiring within 30 days (LG-3928)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@
 version: 2.1
 
 orbs:
-  jq: circleci/jq@2.2.0
   slack: circleci/slack@3.4.2
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,12 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
+
+orbs:
+  jq: circleci/jq@2.2.0
+  slack: circleci/slack@3.4.2
+
 jobs:
   build:
     docker:
@@ -27,19 +32,7 @@ jobs:
 
     steps:
       - checkout
-
-      - restore-cache:
-          keys:
-            - v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
-      - run:
-          name: Install dependencies
-          command: |
-            gem install bundler
-            bundle check || bundle install --deployment --jobs=4 --retry=3 --without deploy development doc production --path vendor/bundle
-      - save-cache:
-          key: v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
+      - install-deps
 
       - run:
           name: Install Code Climate Test Reporter
@@ -101,6 +94,60 @@ jobs:
           docker build -t logindotgov/pki:$CIRCLE_TAG -f Dockerfile .
           echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
           docker push logindotgov/pki:$CIRCLE_TAG
+  install-deps:
+    steps:
+      - restore-cache:
+          keys:
+            - v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install dependencies
+          command: |
+            gem install bundler
+            bundle check || bundle install --deployment --jobs=4 --retry=3 --without deploy development doc production --path vendor/bundle
+      - save-cache:
+          key: v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+  check-expiring-certs-config:
+    docker:
+      # Specify the Ruby version you desire here
+      - image: circleci/ruby:2.6-node-browsers
+        environment:
+          RAILS_ENV: test
+          CC_TEST_REPORTER_ID: c88a6f4af1fbf80e0fc9a5593ebff124b2f940645b1eacb5adb681522bbf650e
+          COVERAGE: true
+          # PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/postgres:9.5-alpine
+        environment:
+          POSTGRES_USER: circleci
+
+      - image: redis:4.0.1
+
+    working_directory: ~/identity-pki
+
+    steps:
+      - checkout
+      - install-deps
+      - run:
+          name: Test Setup
+          command: |
+            cp config/application.yml.example config/application.yml
+            bundle exec rake db:setup --trace
+      - run:
+          name: Check for expiring certs
+          command: |
+            bundle exec rake certs:print_expiring
+
+      - slack/status:
+          fail_only: true
+          failure_message: ":piv-card::red_circle::scream: identity-pki has certs expiring within 30 days"
+          include_project_field: false
+
 workflows:
   version: 2
   release:
@@ -115,3 +162,14 @@ workflows:
           filters:
             tags:
               only: "/^[0-9]{4}-[0-9]{2}-[0-9]{2,}.*/"
+  daily-30d-expiring-cert:
+    jobs:
+      - check-expiring-certs-config
+    triggers:
+      - schedule:
+          # Once a day at 12pm
+          cron: "0 12 * * *"
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ commands:
           command: |
             gem install bundler
             bundle check || bundle install --deployment --jobs=4 --retry=3 --without deploy development doc production --path vendor/bundle
-      - save-cache:
+      - save_cache:
           key: v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,22 +95,6 @@ jobs:
           echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
           docker push logindotgov/pki:$CIRCLE_TAG
 
-commands:
-  install-deps:
-    steps:
-      - restore-cache:
-          keys:
-            - v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
-      - run:
-          name: Install dependencies
-          command: |
-            gem install bundler
-            bundle check || bundle install --deployment --jobs=4 --retry=3 --without deploy development doc production --path vendor/bundle
-      - save-cache:
-          key: v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-
   check-expiring-certs-config:
     docker:
       # Specify the Ruby version you desire here
@@ -149,6 +133,22 @@ commands:
           fail_only: true
           failure_message: ":piv-card::red_circle::scream: identity-pki has certs expiring within 30 days"
           include_project_field: false
+
+commands:
+  install-deps:
+    steps:
+      - restore-cache:
+          keys:
+            - v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install dependencies
+          command: |
+            gem install bundler
+            bundle check || bundle install --deployment --jobs=4 --retry=3 --without deploy development doc production --path vendor/bundle
+      - save-cache:
+          key: v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
 commands:
   install-deps:
     steps:
-      - restore-cache:
+      - restore_cache:
           keys:
             - v2-identity-pki-bundle-{{ checksum "Gemfile.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,8 @@ jobs:
           docker build -t logindotgov/pki:$CIRCLE_TAG -f Dockerfile .
           echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
           docker push logindotgov/pki:$CIRCLE_TAG
+
+commands:
   install-deps:
     steps:
       - restore-cache:

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -44,8 +44,7 @@ class Certificate
       signing_key_id == other.signing_key_id
   end
 
-  def expired?
-    now = Time.zone.now
+  def expired?(now = Time.zone.now)
     not_before > now || now > not_after # expiration bounds
   end
 

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -10,4 +10,23 @@ namespace :certs do
       File.delete(file)
     end
   end
+
+  desc 'Print expiring certs'
+  task print_expiring: :environment do
+    deadline = 30.days.from_now
+
+    expiring_certs = CertificateStore.instance.select do |cert|
+      cert.expired?(deadline)
+    end
+
+    if expiring_certs.present?
+      puts "Expiring Certs found, deadline: #{deadline}"
+      expiring_certs.each do |cert|
+        puts "- Expiration: #{cert.not_after}"
+        puts "  Subject: #{cert.subject}"
+        puts "  Issuer: #{cert.issuer}"
+      end
+      exit 1
+    end
+  end
 end

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -25,6 +25,7 @@ namespace :certs do
         puts "- Expiration: #{cert.not_after}"
         puts "  Subject: #{cert.subject}"
         puts "  Issuer: #{cert.issuer}"
+        puts "  Key ID: #{cert.key_id}"
       end
       exit 1
     end


### PR DESCRIPTION
- Run the task nightly in CircleCI

Here's some example output. Bad news, we have a cert expiring tomorrow 😱 

```
Expiring Certs found, deadline: 2021-01-13 23:58:57 UTC
- Expiration: 2020-12-15 21:10:27 UTC
  Subject: /C=US/O=Entrust/OU=Certification Authorities/OU=Entrust Managed Services Root CA
  Issuer: /C=US/O=U.S. Government/OU=FPKI/CN=Federal Common Policy CA
  Key ID: 9C:62:66:26:9D:71:B6:A7:75:53:64:E1:AC:B1:C7:25:3C:44:5D:0D
- Expiration: 2021-01-12 00:52:59 UTC
  Subject: /C=US/O=ORC PKI/CN=ORC SSP 3
  Issuer: /C=US/O=U.S. Government/OU=FPKI/CN=Federal Common Policy CA
  Key ID: 6A:88:6D:52:FC:B1:44:9E:30:AE:33:18:4D:C0:39:9D:96:6B:24:B0
```