### PR TITLE
Fix expiring certs slack check (LG-3928)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,11 +166,11 @@ workflows:
   daily-30d-expiring-cert:
     jobs:
       - check-expiring-certs-config
-    triggers:
-      - schedule:
-          # Once a day at 12pm
-          cron: "0 12 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    # triggers:
+    #   - schedule:
+    #       # Once a day at 12pm
+    #       cron: "0 12 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,11 +166,11 @@ workflows:
   daily-30d-expiring-cert:
     jobs:
       - check-expiring-certs-config
-    # triggers:
-    #   - schedule:
-    #       # Once a day at 12pm
-    #       cron: "0 12 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - master
+    triggers:
+      - schedule:
+          # Once a day at 12pm
+          cron: "0 12 * * *"
+          filters:
+            branches:
+              only:
+                - master

--- a/app/services/certificate_store.rb
+++ b/app/services/certificate_store.rb
@@ -28,6 +28,7 @@ class CertificateStore # rubocop:disable Metrics/ClassLength
     Dir.chdir(dir) do
       Dir.glob(File.join('**', '*.pem')).each do |file|
         next if file == 'all_certs_deploy.pem'
+
         add_pem_file(file)
       end
     end
@@ -82,6 +83,7 @@ class CertificateStore # rubocop:disable Metrics/ClassLength
   def x509_certificate_chain_to_root(cert, cert_root_id)
     signing_key_id = cert.signing_key_id
     return [] unless signing_key_id
+
     @certificates.values_at(
       *@graph.dijkstra_shortest_path(Hash.new(1), signing_key_id, cert_root_id)
     )
@@ -138,10 +140,8 @@ class CertificateStore # rubocop:disable Metrics/ClassLength
   end
 
   def extract_certs(raw)
-    raw.split(END_CERTIFICATE).map(&method(:cert_from_pem)).compact.select(&:ca_capable?)
-  end
-
-  def cert_from_pem(pem)
-    Certificate.new(OpenSSL::X509::Certificate.new(pem + END_CERTIFICATE)) if pem.strip.present?
+    raw.split(END_CERTIFICATE).map do |pem|
+      Certificate.new(OpenSSL::X509::Certificate.new(pem + END_CERTIFICATE)) if pem.strip.present?
+    end.compact.select(&:ca_capable?)
   end
 end

--- a/app/services/certificate_store.rb
+++ b/app/services/certificate_store.rb
@@ -23,6 +23,16 @@ class CertificateStore # rubocop:disable Metrics/ClassLength
     instance.reset
   end
 
+  # load all of the files in config/certs
+  def load_certs!
+    Dir.chdir(Figaro.env.certificate_store_directory) do
+      Dir.glob(File.join('**', '*.pem')).each do |file|
+        next if file == 'all_certs_deploy.pem'
+        add_pem_file(file)
+      end
+    end
+  end
+
   def_delegators :@certificates, :[], :count, :empty?, :map
   def_delegators :certificates, :each, :select
   def_delegators CertificateStore,

--- a/app/services/certificate_store.rb
+++ b/app/services/certificate_store.rb
@@ -24,8 +24,8 @@ class CertificateStore # rubocop:disable Metrics/ClassLength
   end
 
   # load all of the files in config/certs
-  def load_certs!
-    Dir.chdir(Figaro.env.certificate_store_directory) do
+  def load_certs!(dir: Figaro.env.certificate_store_directory)
+    Dir.chdir(dir) do
       Dir.glob(File.join('**', '*.pem')).each do |file|
         next if file == 'all_certs_deploy.pem'
         add_pem_file(file)

--- a/config/initializers/certificate_store.rb
+++ b/config/initializers/certificate_store.rb
@@ -1,11 +1,3 @@
 unless File.basename($PROGRAM_NAME) == 'rake' && ARGV.any? { |arg| arg.start_with?('db:') }
-  cert_store = CertificateStore.instance
-
-  # load all of the files in config/certs
-  Dir.chdir(Figaro.env.certificate_store_directory) do
-    Dir.glob(File.join('**', '*.pem')).each do |file|
-      next if file == 'all_certs_deploy.pem'
-      cert_store.add_pem_file(file)
-    end
-  end
+  CertificateStore.instance.load_certs!
 end

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -15,9 +15,12 @@ namespace :certs do
   task print_expiring: :environment do
     deadline = 30.days.from_now
 
+    puts "deadline: #{deadline}"
+
     cert_store = CertificateStore.instance
     cert_store.load_certs!
     expiring_certs = cert_store.select do |cert|
+      puts "checking cert #{cert.subject}"
       cert.expired?(deadline)
     end
 

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -18,7 +18,7 @@ namespace :certs do
     puts "deadline: #{deadline}"
 
     cert_store = CertificateStore.instance
-    cert_store.load_certs!
+    cert_store.load_certs!(dir: Rails.root.join('config/certs'))
     expiring_certs = cert_store.select do |cert|
       puts "checking cert #{cert.subject}"
       cert.expired?(deadline)

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -15,7 +15,10 @@ namespace :certs do
   task print_expiring: :environment do
     deadline = 30.days.from_now
 
+    puts "checking deadline #{deadline}"
+
     expiring_certs = CertificateStore.instance.select do |cert|
+      puts "checking cert #{cert.subject}"
       cert.expired?(deadline)
     end
 

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -15,12 +15,10 @@ namespace :certs do
   task print_expiring: :environment do
     deadline = 30.days.from_now
 
-    puts "deadline: #{deadline}"
-
     cert_store = CertificateStore.instance
     cert_store.load_certs!(dir: Rails.root.join('config/certs'))
+
     expiring_certs = cert_store.select do |cert|
-      puts "checking cert #{cert.subject}"
       cert.expired?(deadline)
     end
 

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -15,10 +15,9 @@ namespace :certs do
   task print_expiring: :environment do
     deadline = 30.days.from_now
 
-    puts "checking deadline #{deadline}"
-
-    expiring_certs = CertificateStore.instance.select do |cert|
-      puts "checking cert #{cert.subject}"
+    cert_store = CertificateStore.instance
+    cert_store.load_certs!
+    expiring_certs = cert_store.select do |cert|
       cert.expired?(deadline)
     end
 

--- a/spec/services/certificate_store_spec.rb
+++ b/spec/services/certificate_store_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe CertificateStore do
   let(:intermediate_certs) { certificates_in_collection(cert_collection, :type, :intermediate) }
   let(:leaf_certs) { certificates_in_collection(cert_collection, :type, :leaf) }
 
+  describe '#load_certs!' do
+    it 'loads the certs in a directory' do
+      expect { certificate_store.load_certs!(dir: Rails.root.join('config/certs')) }.
+        to(change { certificate_store.certificates.count })
+    end
+  end
+
   describe 'with loaded certificates' do
     let(:ca_file_path) { data_file_path('certs.pem') }
 


### PR DESCRIPTION
**Before**: Because it was running in the test environment, the check would check against our test certs, which are not expiring

**Now**: Checks against our "prod" certs, which are expiring

Example of correctly failing alert:

<img width="423" alt="Screen Shot 2020-12-17 at 10 02 08 AM" src="https://user-images.githubusercontent.com/458784/102525321-f3fcf480-404e-11eb-951d-a64a1ccf13aa.png">
