### PR TITLE
Fallback to CRLs if there is OCSP parsing or timeout error

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -64,14 +64,6 @@ class Certificate
   end
 
   def validate_untrusted_root
-    validate_untrusted_root_with_exceptions
-  rescue OpenSSL::OCSP::OCSPError
-    'ocsp_error'
-  rescue Timeout::Error
-    'timeout'
-  end
-
-  def validate_untrusted_root_with_exceptions
     if self_signed?
       'self-signed cert'
     elsif !signature_verified?

--- a/spec/services/ocsp_service_spec.rb
+++ b/spec/services/ocsp_service_spec.rb
@@ -278,6 +278,16 @@ RSpec.describe OCSPService do
 
     let(:status) { :invalid }
 
+    before do
+      described_class.clear_ocsp_response_cache
+      allow(IO).to receive(:binread).with(ca_file_path).and_return(ca_file_content)
+      allow(Figaro.env).to receive(:trusted_ca_root_identifiers).and_return(
+        root_cert_key_ids.join(',')
+      )
+      certificate_store.clear_root_identifiers
+      certificate_store.add_pem_file(ca_file_path)
+    end
+
     context "that isn't an OCSP response at all" do
       before(:each) do
         stub_request(:post, 'http://ocsp.example.com/').


### PR DESCRIPTION
**Why**: If we fail to get a proper response from an OCSP server, we should fallback to our CRLs instead of marking the cert invalid.