### PR TITLE
Map piv/cac to the Federal Bridge CA if using valid policy OIDs (LG-3604)

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -64,7 +64,7 @@ class Certificate
     end
   end
 
-  def validate_untrusted_root(is_leaf: )
+  def validate_untrusted_root(is_leaf:)
     if self_signed?
       'self-signed cert'
     elsif !signature_verified?

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -57,7 +57,7 @@ class Certificate
       'expired'
     elsif trusted_root?
       # The other checks are all irrelevant if we trust the root.
-      raise 'trusted root missing from store' if CertificateStore.instance[key_id].blank?
+      raise "trusted root missing from store #{key_id}" if CertificateStore.instance[key_id].blank?
       'valid'
     else
       validate_untrusted_root(is_leaf: is_leaf)

--- a/app/services/issuing_ca_service.rb
+++ b/app/services/issuing_ca_service.rb
@@ -57,7 +57,7 @@ class IssuingCaService
       handle_exception(UnexpectedPKCS7Response.new(response.body))
       []
     end
-  rescue OpenSSL::PKCS7::PKCS7Error, ArgumentError => e
+  rescue OpenSSL::PKCS7::PKCS7Error, ArgumentError, Errno::ECONNREFUSED, Net::ReadTimeout => e
     handle_exception(e)
     []
   end

--- a/app/services/issuing_ca_service.rb
+++ b/app/services/issuing_ca_service.rb
@@ -1,7 +1,8 @@
 class IssuingCaService
   # TODO: Only allow downloading bundles from allowed domains
   # Do this for all of the stored certs
-  CA_ISSUER_HOST_ALLOW_LIST = ['sspweb.managed.entrust.com']
+  CA_ISSUER_HOST_ALLOW_LIST = Figaro.env.ca_issuer_host_allow_list.split(',')
+
   class UnexpectedPKCS7Response < StandardError; end
 
   CA_RESPONSE_CACHE_EXPIRATION = 60.minutes

--- a/app/services/issuing_ca_service.rb
+++ b/app/services/issuing_ca_service.rb
@@ -1,0 +1,72 @@
+class IssuingCaService
+  # TODO: Only allow downloading bundles from allowed domains
+  # Do this for all of the stored certs
+  CA_ISSUER_HOST_ALLOW_LIST = ['sspweb.managed.entrust.com']
+  class UnexpectedPKCS7Response < StandardError; end
+
+  CA_RESPONSE_CACHE_EXPIRATION = 60.minutes
+
+  def self.fetch_signing_key_for_cert(cert)
+    return nil unless cert.aia && cert.aia['CA Issuers'].is_a?(Array)
+    ca_issuers = cert.aia['CA Issuers'].map do |issuer|
+      issuer = issuer.to_s
+      next unless issuer.starts_with?('URI')
+      issuer = issuer.gsub(/^URI:/, '')
+      uri = URI.parse(issuer)
+      next unless uri.scheme == 'http'
+      next unless allowed_host?(uri.host)
+      uri
+    end.compact
+
+    ca_issuers.each do |ca_issuer_uri|
+      signing_cert = fetch_issuing_certificate(ca_issuer_uri, cert.signing_key_id)
+      return signing_cert if signing_cert.present?
+    end
+
+    nil
+  end
+
+  def self.fetch_issuing_certificate(ca_issuer_uri, signing_key_id)
+    @ca_certificates_response_cache ||= MiniCache::Store.new
+    key = [ca_issuer_uri.to_s, signing_key_id].inspect
+
+    cached_result = @ca_certificates_response_cache.get(key)
+    return cached_result if @ca_certificates_response_cache.set?(key)
+
+    ca_x509_certificates = fetch_certificates(ca_issuer_uri)
+
+    ca_x509_certificates.each do |ca_x509_certificate|
+      ca_certificate = Certificate.new(ca_x509_certificate)
+      if signing_key_id == ca_certificate.key_id
+        return @ca_certificates_response_cache.set(key, ca_certificate, expires_in: CA_RESPONSE_CACHE_EXPIRATION)
+      end
+    end
+
+    @ca_certificates_response_cache.set(key, nil, expires_in: CA_RESPONSE_CACHE_EXPIRATION)
+  end
+
+  def self.fetch_certificates(issuer_uri)
+    http = Net::HTTP.new(issuer_uri.hostname, issuer_uri.port)
+    response = http.get(issuer_uri.path)
+    if response.kind_of?(Net::HTTPSuccess)
+      OpenSSL::PKCS7.new(response.body).certificates
+    else
+      handle_exception(UnexpectedPKCS7Response.new(response.body))
+      []
+    end
+  rescue OpenSSL::PKCS7::PKCS7Error, ArgumentError => e
+    handle_exception(e)
+    []
+  end
+
+  def self.allowed_host?(host)
+    return true if CA_ISSUER_HOST_ALLOW_LIST.include?(host)
+
+    Rails.logger.info("CA Issuer Host Not Allowed: #{host}")
+    false
+  end
+
+  def self.handle_exception(exception)
+    NewRelic::Agent.notice_error(exception)
+  end
+end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -11,6 +11,8 @@ aws_http_timeout: '5'
 http_read_timeout: '5'
 http_open_timeout: '5'
 
+ca_issuer_host_allow_list: "repo.fpki.gov,crl.disa.mil,http.fpki.gov,ssp-aia.symauth.com,pki.treasury.gov,rootweb.managed.entrust.com,aia1.ssp-strong-id.net,pki.treas.gov,crls.pki.state.gov,sspweb.managed.entrust.com/"
+
 # Trusted roots:
 # AD:0C:7A:75:5C:E5:F3:98:C4:79:98:0E:AC:28:FD:97:F4:E7:02:FC - Federal Common Policy
 # 49:74:BB:0C:5E:BA:7A:FE:02:54:EF:7B:A0:C6:95:C6:09:80:70:96 DoD Root CA 2

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -86,6 +86,7 @@ test:
 
 production:
   aws_region:
+  ca_issuer_host_allow_list: ''
   client_cert_escaped: 'true'
   certificate_store_directory: 'config/certs'
   nonce_bloom_filter_enabled: 'false'

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -81,6 +81,8 @@ test:
   database_username: ''
   secret_key_base: ''
   certificate_store_directory: 'config/test-certs'
+  ca_issuer_host_allow_list: 'uri1.example.com,uri2.example.com'
+
 
 production:
   aws_region:

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -11,7 +11,7 @@ aws_http_timeout: '5'
 http_read_timeout: '5'
 http_open_timeout: '5'
 
-ca_issuer_host_allow_list: "repo.fpki.gov,crl.disa.mil,http.fpki.gov,ssp-aia.symauth.com,pki.treasury.gov,rootweb.managed.entrust.com,aia1.ssp-strong-id.net,pki.treas.gov,crls.pki.state.gov,sspweb.managed.entrust.com/"
+ca_issuer_host_allow_list: "repo.fpki.gov,crl.disa.mil,http.fpki.gov,ssp-aia.symauth.com,pki.treasury.gov,rootweb.managed.entrust.com,aia1.ssp-strong-id.net,pki.treas.gov,crls.pki.state.gov,sspweb.managed.entrust.com"
 
 # Trusted roots:
 # AD:0C:7A:75:5C:E5:F3:98:C4:79:98:0E:AC:28:FD:97:F4:E7:02:FC - Federal Common Policy

--- a/spec/controllers/health/certs_controller_spec.rb
+++ b/spec/controllers/health/certs_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Health::CertsController do
     it 'renders a status as JSON' do
       action
 
-      expect(response.content_type).to eq('application/json')
+      expect(response.media_type).to eq('application/json')
       expect(JSON.parse(response.body, symbolize_names: true)).to include(:healthy)
     end
 

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -144,6 +144,19 @@ RSpec.describe Certificate do
         expect(certificate.signature_verified?).to be_truthy
       end
     end
+
+    context 'for a intermediate certificate fetched from the IssuingCaService' do
+      it 'is valid if the policy OIDs are recognized and allowed' do
+        # Simulate the intermediate cert not being present in the certificate store
+        intermediate_cert = CertificateStore.instance.delete(certificate.signing_key_id)
+
+        expect(IssuingCaService).to receive(
+          :fetch_signing_key_for_cert,
+        ).with(certificate).and_return(intermediate_cert)
+
+        expect(certificate.signature_verified?).to be_truthy
+      end
+    end
   end
 
   describe 'to_pem' do
@@ -355,13 +368,36 @@ RSpec.describe Certificate do
       certificate_store.add_pem_file(ca_file_path)
     end
 
-    it 'verifies the certificate' do
-      expect(certificate.valid?).to be_truthy
+    context 'when its intermediate certs are in the CertificateStore' do
+      it 'verifies the certificate' do
+        expect(certificate.valid?(is_leaf: true)).to be_truthy
+      end
+
+      it 'logs the cert in S3 when creating a token' do
+        expect(CertificateLoggerService).to receive(:log_certificate).with(certificate)
+        certificate.token({})
+      end
     end
 
-    it 'logs the cert in S3 when creating a token' do
-      expect(CertificateLoggerService).to receive(:log_certificate).with(certificate)
-      certificate.token({})
+    context 'when its intermediate certs must be fetched from a CA issuer URL' do
+      it 'does not verify the certificate' do
+        intermediate_cert = CertificateStore.instance.delete(certificate.signing_key_id)
+        expect(IssuingCaService).to receive(
+          :fetch_signing_key_for_cert,
+        ).with(certificate).and_return(intermediate_cert)
+
+        expect(certificate.valid?(is_leaf: true)).to be_falsey
+      end
+
+      it 'logs the cert in S3 when creating a token' do
+        intermediate_cert = CertificateStore.instance.delete(certificate.signing_key_id)
+        expect(IssuingCaService).to receive(
+          :fetch_signing_key_for_cert,
+        ).twice.with(certificate).and_return(intermediate_cert)
+
+        expect(CertificateLoggerService).to receive(:log_certificate).with(certificate)
+        certificate.token({})
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
     CertificateStore.instance.clear_root_identifiers
     Certificate.clear_revocation_cache
     OCSPService.clear_ocsp_response_cache
+    IssuingCaService.clear_ca_certificates_response_cache!
   end
 
   config.before(:each, type: :controller) do

--- a/spec/services/issuing_ca_service_spec.rb
+++ b/spec/services/issuing_ca_service_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe IssuingCaService do
   before do
     allow(described_class).to receive(:ca_issuer_host_allow_list).and_return(['example.com'])
-
-    described_class.clear_ca_certificates_response_cache!
   end
 
   let(:certificate_set) do

--- a/spec/services/issuing_ca_service_spec.rb
+++ b/spec/services/issuing_ca_service_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe IssuingCaService do
+  before do
+    allow(described_class).to receive(:ca_issuer_host_allow_list).and_return(['example.com'])
+
+    described_class.clear_ca_certificates_response_cache!
+  end
+
+  describe '.fetch_signing_key_for_cert' do
+    context 'when the the signing key is available at the issuer url' do
+      it 'returns the certificate' do
+        certificate_set = create_certificate_set(
+          root_count: 1, intermediate_count: 1, leaf_count: 1,
+        )
+        certificate = certificates_in_collection(certificate_set, :type, :leaf).first
+        signing_cert = certificates_in_collection(certificate_set, :type, :intermediate).first
+
+        pkcs7_bundle = OpenSSL::PKCS7.new
+        pkcs7_bundle.type = 'signed'
+        pkcs7_bundle.add_certificate(signing_cert.x509_cert)
+        pkcs7_bundle.add_data("")
+        pkcs7_response_body = pkcs7_bundle.to_der
+
+        stub_request(:get, 'http://example.com').to_return(body: pkcs7_response_body)
+
+        fetched_cert = described_class.fetch_signing_key_for_cert(certificate)
+
+        expect(fetched_cert).to eq(signing_cert)
+      end
+    end
+
+    context 'when called twice for the same issuing certificate' do
+      it 'caches the response and does not make a second request'
+    end
+
+    context 'when a URI has a host that is not in the allow list' do
+      it 'logs and does not make a request to that host'
+    end
+
+    context 'when there is an HTTP error fetching the certificate' do
+      it 'returns nil and logs the error'
+    end
+
+    context 'when the PKCS7 response is invalid' do
+      it 'returns nil and logs the error'
+    end
+
+    context 'when the certificate does not have and CA Issuer URIs' do
+      it 'returns nil'
+    end
+
+    context 'when the certificate does not have authority information access' do
+      it 'returns nil'
+    end
+  end
+end

--- a/spec/services/issuing_ca_service_spec.rb
+++ b/spec/services/issuing_ca_service_spec.rb
@@ -7,22 +7,20 @@ RSpec.describe IssuingCaService do
     described_class.clear_ca_certificates_response_cache!
   end
 
+  let(:certificate_set) do
+    create_certificate_set(
+      root_count: 1, intermediate_count: 1, leaf_count: 1,
+    )
+  end
+
   describe '.fetch_signing_key_for_cert' do
     context 'when the the signing key is available at the issuer url' do
       it 'returns the certificate' do
-        certificate_set = create_certificate_set(
-          root_count: 1, intermediate_count: 1, leaf_count: 1,
-        )
         certificate = certificates_in_collection(certificate_set, :type, :leaf).first
         signing_cert = certificates_in_collection(certificate_set, :type, :intermediate).first
 
-        pkcs7_bundle = OpenSSL::PKCS7.new
-        pkcs7_bundle.type = 'signed'
-        pkcs7_bundle.add_certificate(signing_cert.x509_cert)
-        pkcs7_bundle.add_data("")
-        pkcs7_response_body = pkcs7_bundle.to_der
-
-        stub_request(:get, 'http://example.com').to_return(body: pkcs7_response_body)
+        pkcs7_bundle = build_pkc7_bundle(signing_cert.x509_cert)
+        stub_request(:get, 'http://example.com').to_return(body: pkcs7_bundle.to_der)
 
         fetched_cert = described_class.fetch_signing_key_for_cert(certificate)
 
@@ -31,27 +29,79 @@ RSpec.describe IssuingCaService do
     end
 
     context 'when called twice for the same issuing certificate' do
-      it 'caches the response and does not make a second request'
+      it 'caches the response and does not make a second request' do
+        certificate = certificates_in_collection(certificate_set, :type, :leaf).first
+        signing_cert = certificates_in_collection(certificate_set, :type, :intermediate).first
+
+        pkcs7_bundle = build_pkc7_bundle(signing_cert.x509_cert)
+        stub_request(:get, 'http://example.com').to_return(body: pkcs7_bundle.to_der)
+
+        fetched_cert1 = described_class.fetch_signing_key_for_cert(certificate)
+        fetched_cert2 = described_class.fetch_signing_key_for_cert(certificate)
+
+        expect(fetched_cert1).to eq(signing_cert)
+        expect(fetched_cert2).to eq(signing_cert)
+        expect(a_request(:get, "http://example.com")).to have_been_made.once
+      end
     end
 
     context 'when a URI has a host that is not in the allow list' do
-      it 'logs and does not make a request to that host'
+      it 'logs and does not make a request to that host' do
+        allow(described_class).to receive(:ca_issuer_host_allow_list).and_return(['example2.com'])
+
+        certificate = certificates_in_collection(certificate_set, :type, :leaf).first
+        expect(Rails.logger).to receive(:info).with('CA Issuer Host Not Allowed: example.com')
+        fetched_cert = described_class.fetch_signing_key_for_cert(certificate)
+        expect(fetched_cert).to eq nil
+      end
     end
 
     context 'when there is an HTTP error fetching the certificate' do
-      it 'returns nil and logs the error'
+      it 'returns nil and logs the error' do
+        stub_request(:get, 'http://example.com').to_return(status: [500, 'Internal Server Error'])
+
+        certificate = certificates_in_collection(certificate_set, :type, :leaf).first
+        expect(NewRelic::Agent).to receive(:notice_error).with(
+          IssuingCaService::UnexpectedPKCS7Response
+        )
+        fetched_cert = described_class.fetch_signing_key_for_cert(certificate)
+        expect(fetched_cert).to eq nil
+      end
     end
 
     context 'when the PKCS7 response is invalid' do
-      it 'returns nil and logs the error'
+      it 'returns nil and logs the error' do
+        stub_request(:get, 'http://example.com').to_return(body: 'bad pkcs7 response')
+
+        certificate = certificates_in_collection(certificate_set, :type, :leaf).first
+        expect(NewRelic::Agent).to receive(:notice_error).with(ArgumentError)
+        fetched_cert = described_class.fetch_signing_key_for_cert(certificate)
+        expect(fetched_cert).to eq nil
+      end
     end
 
     context 'when the certificate does not have and CA Issuer URIs' do
-      it 'returns nil'
+      it 'returns nil' do
+        certificate = certificates_in_collection(certificate_set, :type, :leaf).first
+        certificate.x509_cert
+      end
     end
 
     context 'when the certificate does not have authority information access' do
-      it 'returns nil'
+      it 'returns nil' do
+        certificate = certificates_in_collection(certificate_set, :type, :leaf).first
+        allow(certificate).to receive(:aia).and_return({})
+        fetched_cert = described_class.fetch_signing_key_for_cert(certificate)
+        expect(fetched_cert).to eq nil
+      end
     end
+  end
+
+  def build_pkc7_bundle(x509_cert)
+    pkcs7_bundle = OpenSSL::PKCS7.new
+    pkcs7_bundle.type = 'signed'
+    pkcs7_bundle.add_certificate(x509_cert)
+    pkcs7_bundle.add_data("")
+    pkcs7_bundle
   end
 end


### PR DESCRIPTION
Creates a new service that will attempt to verify a cert is issued by a trusted authority and has valid policy OIDs. The service is only permitted to download bundles from specified CA issuers via configuration. Missing hosts will be logged so we can consider adding them in the future. These hosts will also have to be coordinated with the outbound proxy configuration.

Policy OIDs are only checked for the downloaded certs. If a cert is stored, we continue to not check policy to avoid breaking existing functionality.