### PR TITLE
Rake task to look for replacement certs (LG-3932)

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -82,8 +82,8 @@ class Certificate
     validate_cert(is_leaf: is_leaf) == 'valid'
   end
 
-  def pem_filename
-    "#{subject.to_s(OpenSSL::X509::Name::COMPAT)}.pem"
+  def pem_filename(suffix: nil)
+    "#{subject.to_s(OpenSSL::X509::Name::COMPAT)}#{suffix}.pem"
   end
 
   def to_pem

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -122,13 +122,15 @@ class Certificate
   end
 
   def aia
-    aia_hash = parse_extension_to_hash(get_extension('authorityInfoAccess')) || {}
-    @aia ||= aia_hash
+    @aia ||= begin
+      parse_extension_to_hash(get_extension('authorityInfoAccess')) || {}
+    end
   end
 
   def subject_info_access
-    sia_hash = parse_extension_to_hash(get_extension('subjectInfoAccess')) || {}
-    @subject_info_access ||= sia_hash
+    @subject_info_access ||= begin
+      parse_extension_to_hash(get_extension('subjectInfoAccess')) || {}
+    end
   end
 
   def token(extra)

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -130,6 +130,15 @@ class Certificate
       end
   end
 
+  def sia
+    @sia ||= get_extension('subjectInfoAccess')&.
+      split(/\n/)&.
+      map { |line| line.split(/\s*-\s*/, 2) }&.
+      each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(key, value), memo|
+        memo[key] << value
+      end
+  end
+
   def token(extra)
     if valid?(is_leaf: true)
       token_for_valid_certificate(extra)
@@ -165,6 +174,10 @@ class Certificate
 
   def valid_policies?
     critical_policies_recognized? && allowed_by_policy?
+  end
+
+  def sha1_fingerprint
+    OpenSSL::Digest::SHA1.new(x509_cert.to_der).to_s
   end
 
   private

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -136,7 +136,7 @@ class Certificate
       map { |line| line.split(/\s*-\s*/, 2) }&.
       each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(key, value), memo|
         memo[key] << value
-      end
+      end || {}
   end
 
   def token(extra)

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -130,8 +130,8 @@ class Certificate
       end
   end
 
-  def sia
-    @sia ||= get_extension('subjectInfoAccess')&.
+  def subject_info_access
+    @subject_info_access ||= get_extension('subjectInfoAccess')&.
       split(/\n/)&.
       map { |line| line.split(/\s*-\s*/, 2) }&.
       each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(key, value), memo|

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -122,15 +122,11 @@ class Certificate
   end
 
   def aia
-    @aia ||= begin
-      parse_extension_to_hash(get_extension('authorityInfoAccess')) || {}
-    end
+    @aia ||= parse_extension_to_hash(get_extension('authorityInfoAccess')) || {}
   end
 
   def subject_info_access
-    @subject_info_access ||= begin
-      parse_extension_to_hash(get_extension('subjectInfoAccess')) || {}
-    end
+    @subject_info_access ||= parse_extension_to_hash(get_extension('subjectInfoAccess')) || {}
   end
 
   def token(extra)

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -127,7 +127,7 @@ class Certificate
       map { |line| line.split(/\s*-\s*/, 2) }&.
       each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(key, value), memo|
         memo[key] << value
-      end
+      end || {}
   end
 
   def subject_info_access

--- a/app/services/issuing_ca_service.rb
+++ b/app/services/issuing_ca_service.rb
@@ -16,25 +16,6 @@ class IssuingCaService
     nil
   end
 
-  def self.fetch_ca_repository_certs_for_cert(cert)
-    return [] if cert.subject_info_access.blank? || !cert.subject_info_access['CA Repository'].is_a?(Array)
-
-    repository_uris = cert.subject_info_access['CA Repository'].map do |repo|
-      repo = repo.to_s
-      next unless repo.starts_with?('URI')
-      repo = repo.gsub(/^URI:/, '')
-      uri = URI.parse(repo)
-      next unless uri.scheme == 'http'
-      uri
-    end.compact
-
-    repository_uris.map do |repository_uri|
-      IssuingCaService.fetch_certificates(repository_uri).map do |x509_cert|
-        Certificate.new(x509_cert)
-      end
-    end.flatten
-  end
-
   def self.fetch_issuing_certificate(ca_issuer_uri, signing_key_id)
     @ca_certificates_response_cache ||= MiniCache::Store.new
     key = [ca_issuer_uri.to_s, signing_key_id].inspect
@@ -58,13 +39,22 @@ class IssuingCaService
     return [] if cert.aia.blank? || !cert.aia['CA Issuers'].is_a?(Array)
 
     cert.aia['CA Issuers'].map do |issuer|
-      issuer = issuer.to_s
-      next unless issuer.starts_with?('URI')
-      issuer = issuer.gsub(/^URI:/, '')
-      uri = URI.parse(issuer)
-      next unless uri.scheme == 'http'
-      uri
+      convert_uri(issuer)
     end.compact
+  end
+
+  def self.fetch_ca_repository_certs_for_cert(cert)
+    return [] if cert.subject_info_access.blank? || !cert.subject_info_access['CA Repository'].is_a?(Array)
+
+    repository_uris = cert.subject_info_access['CA Repository'].map do |repo|
+      convert_uri(repo)
+    end.compact
+
+    repository_uris.map do |repository_uri|
+      IssuingCaService.fetch_certificates(repository_uri).map do |x509_cert|
+        Certificate.new(x509_cert)
+      end
+    end.flatten
   end
 
   def self.clear_ca_certificates_response_cache!
@@ -100,5 +90,14 @@ class IssuingCaService
     CertificateStore.instance.certificates.map do |certificate|
       ca_issuers_for_cert(certificate)
     end.flatten.uniq
+  end
+
+  def self.convert_uri(uri)
+    uri = uri.to_s
+    return nil unless uri.starts_with?('URI')
+    uri = uri.gsub(/^URI:/, '')
+    uri = URI.parse(uri)
+    return nil unless uri.scheme == 'http'
+    uri
   end
 end

--- a/app/services/issuing_ca_service.rb
+++ b/app/services/issuing_ca_service.rb
@@ -17,7 +17,7 @@ class IssuingCaService
   end
 
   def self.fetch_ca_repository_certs_for_cert(cert)
-    return nil if cert.subject_info_access.blank? || !cert.subject_info_access['CA Repository'].is_a?(Array)
+    return [] if cert.subject_info_access.blank? || !cert.subject_info_access['CA Repository'].is_a?(Array)
 
     repository_uris = cert.subject_info_access['CA Repository'].map do |repo|
       repo = repo.to_s

--- a/app/services/issuing_ca_service.rb
+++ b/app/services/issuing_ca_service.rb
@@ -27,9 +27,9 @@ class IssuingCaService
   end
 
   def self.fetch_ca_repository_certs_for_cert(cert)
-    return nil if cert.sia.blank? || !cert.sia['CA Repository'].is_a?(Array)
+    return nil if cert.subject_info_access.blank? || !cert.subject_info_access['CA Repository'].is_a?(Array)
 
-    repository_uris = cert.sia['CA Repository'].map do |repo|
+    repository_uris = cert.subject_info_access['CA Repository'].map do |repo|
       repo = repo.to_s
       next unless repo.starts_with?('URI')
       repo = repo.gsub(/^URI:/, '')

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -95,8 +95,9 @@ namespace :certs do
       path = Pathname.new("./config/certs") + matching_cert.pem_filename
 
       if File.exist?(path)
-        path = Pathname.new("./config/certs") + matching_cert.pem_filename.
-          gsub(/.pem$/, " #{matching_cert.not_after.to_i}.pem")
+        path = Pathname.new("./config/certs") + matching_cert.pem_filename(
+          suffix: " #{matching_cert.not_after.to_i}"
+        )
       end
       puts "Writing certificate to #{path}"
       File.write(path, matching_cert.to_pem)

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -74,6 +74,16 @@ namespace :certs do
         DidYouMean::JaroWinkler.distance(repo_cert.subject.to_s, cert.subject.to_s) > 0.95
     end
     raise "No matching certs in the signing cert's CA repository" if matching_certs.empty?
+
+    puts "Expiring Certificate:"
+    puts "  Expiration: #{cert.not_after}"
+    puts "  Subject: #{cert.subject}"
+    puts "  Issuer: #{cert.issuer}"
+    puts "  SHA1 Fingerpint: #{cert.sha1_fingerprint}"
+    puts "  Key ID: #{cert.key_id}"
+
+    puts ""
+    puts "Potential Replacement Certificates:"
     matching_certs.each_with_index do |matching_cert, index|
       puts "- Index: #{index}"
       puts "  Expiration: #{matching_cert.not_after}"

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -69,7 +69,7 @@ namespace :certs do
     raise "Signing cert #{cert.signing_key_id} is not in store and could not be downloaded" if signing_cert.nil?
 
     matching_certs = repository_certs.select do |repo_cert|
-      repo_cert.key_id != cert.key_id &&
+      repo_cert.serial != cert.serial &&
         repo_cert.ca_capable? &&
         DidYouMean::JaroWinkler.distance(repo_cert.subject.to_s, cert.subject.to_s) > 0.95
     end

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -70,6 +70,7 @@ namespace :certs do
 
     matching_certs = repository_certs.select do |repo_cert|
       repo_cert.key_id != cert.key_id &&
+        repo_cert.ca_capable? &&
         DidYouMean::JaroWinkler.distance(repo_cert.subject.to_s, cert.subject.to_s) > 0.95
     end
     raise "No matching certs in the signing cert's CA repository" if matching_certs.empty?

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -63,7 +63,7 @@ namespace :certs do
 
     raise "Signing cert #{cert.signing_key_id} is not in store and could not be downloaded" if signing_cert.nil?
 
-    puts "Signing Cert subject information access (SIA) extensions: #{signing_cert.sia.inspect}"
+    puts "Signing Cert subject information access (SIA) extensions: #{signing_cert.subject_info_access.inspect}"
 
     repository_certs = IssuingCaService.fetch_ca_repository_certs_for_cert(signing_cert)
     raise "Signing cert #{cert.signing_key_id} is not in store and could not be downloaded" if signing_cert.nil?

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -37,4 +37,74 @@ namespace :certs do
       exit 1
     end
   end
+
+  # Per https://fpki.idmanagement.gov/tools/fpkigraph/:
+  # >Most CA certificates will also have an SIA extension with a URI to the CA certificates
+  # >that have been issued by that CA.
+  #
+  # This task takes a key_id as an argument and fetches that cert from the Certificate Store.
+  # If the cert exists, the signing cert is fetched from the Certificate Store.
+  # If the signing cert has a subject information access extension with a 'CA Repository' key,
+  # the bundle is downloaded. This bundle should contain all of the certs signed by the expiring
+  # cert's signing cert.
+  #
+  # There isn't a guaranteed way to associate an expiring cert with its replacment(s), so we try to
+  # match on the subject.
+  desc 'Find replacement cert'
+  task :find_replacement, [:key_id] => [:environment] do |t, args|
+    cert_store = CertificateStore.instance
+    cert_store.load_certs!(dir: Rails.root.join('config/certs'))
+    key_id = args[:key_id]
+
+    cert = CertificateStore.instance[key_id]
+    raise "Cert #{key_id} is not in CertificateStore" if cert.nil?
+    signing_cert = CertificateStore.instance[cert.signing_key_id] ||
+      IssuingCaService.fetch_signing_key_for_cert(cert)
+
+    raise "Signing cert #{cert.signing_key_id} is not in store and could not be downloaded" if signing_cert.nil?
+
+    puts "Signing Cert subject information access (SIA) extensions: #{signing_cert.sia.inspect}"
+
+    repository_certs = IssuingCaService.fetch_ca_repository_certs_for_cert(signing_cert)
+    raise "Signing cert #{cert.signing_key_id} is not in store and could not be downloaded" if signing_cert.nil?
+
+    matching_certs = repository_certs.select do |repo_cert|
+      repo_cert.key_id != cert.key_id &&
+        DidYouMean::JaroWinkler.distance(repo_cert.subject.to_s, cert.subject.to_s) > 0.95
+    end
+    raise "No matching certs in the signing cert's CA repository" if matching_certs.empty?
+    matching_certs.each_with_index do |matching_cert, index|
+      puts "- Index: #{index}"
+      puts "  Expiration: #{matching_cert.not_after}"
+      puts "  Subject: #{matching_cert.subject}"
+      puts "  Issuer: #{matching_cert.issuer}"
+      puts "  SHA1 Fingerpint: #{matching_cert.sha1_fingerprint}"
+      puts "  Key ID: #{matching_cert.key_id}"
+      puts "  In Certificate Store: #{CertificateStore.instance[matching_cert.key_id].present?}"
+    end
+
+    puts ''
+    puts 'Which cert(s) would you like to download? Use the format 1,2 if selecting multiple.'
+    puts 'Press enter to skip'
+    input = STDIN.gets.strip.split(',').map(&:to_i)
+    puts ''
+
+    return if input.blank?
+
+    Array.wrap(matching_certs[*input]).each do |matching_cert|
+      path = Pathname.new("./config/certs") + matching_cert.pem_filename
+      unique_path = nil
+
+      n = 0
+      if File.exist?(path)
+        path = Pathname.new("./config/certs") + matching_cert.pem_filename.
+          gsub(/.pem$/, " #{matching_cert.not_after.to_i}.pem")
+      end
+      puts "Writing certificate to #{path}"
+      File.write(path, matching_cert.to_pem)
+    end
+
+    puts ''
+    puts 'Double check https://fpki.idmanagement.gov/notifications/#notifications for new and revoked certs'
+  end
 end

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -93,9 +93,7 @@ namespace :certs do
 
     Array.wrap(matching_certs[*input]).each do |matching_cert|
       path = Pathname.new("./config/certs") + matching_cert.pem_filename
-      unique_path = nil
 
-      n = 0
       if File.exist?(path)
         path = Pathname.new("./config/certs") + matching_cert.pem_filename.
           gsub(/.pem$/, " #{matching_cert.not_after.to_i}.pem")

--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe IdentifyController, type: :controller do
 
         context 'when the nonce param is missing' do
           it 'returns a bad request' do
-            get :create, params: {}
+            get :create, params: { redirect_uri: 'http://example.com/' }
             expect(response).to have_http_status(:bad_request)
           end
         end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -239,6 +239,14 @@ RSpec.describe Certificate do
     end
   end
 
+  describe '#sha1_fingerprint' do
+    let(:x509_cert) { leaf_cert }
+
+    it 'returns a string' do
+      expect(certificate.sha1_fingerprint).to be_a(String)
+    end
+  end
+
   describe 'a root cert' do
     let(:x509_cert) { root_cert }
 

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -136,12 +136,20 @@ RSpec.describe Certificate do
     end
 
     context 'for a valid intermediate certificate' do
+      let(:x509_cert) { intermediate_cert }
+
       it 'has valid intermediates' do
         expect(intermediate_certs.all?(&:valid?)).to be_truthy
       end
 
       it 'is valid' do
         expect(certificate.signature_verified?).to be_truthy
+      end
+
+      it 'has subjectInfoAccess information' do
+        expect(certificate.subject_info_access).to_not be_nil
+        expect(certificate.subject_info_access).to have_key 'CA Repository'
+        expect(certificate.subject_info_access['CA Repository'].count).to eq 1
       end
     end
 

--- a/spec/services/issuing_ca_service_spec.rb
+++ b/spec/services/issuing_ca_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe IssuingCaService do
   end
 
   describe '.fetch_signing_key_for_cert' do
-    context 'when the the signing key is available at the issuer url' do
+    context 'when the signing key is available at the issuer url' do
       it 'returns the certificate' do
         certificate = certificates_in_collection(certificate_set, :type, :leaf).first
         signing_cert = certificates_in_collection(certificate_set, :type, :intermediate).first
@@ -91,6 +91,22 @@ RSpec.describe IssuingCaService do
         allow(certificate).to receive(:aia).and_return({})
         fetched_cert = described_class.fetch_signing_key_for_cert(certificate)
         expect(fetched_cert).to eq nil
+      end
+    end
+  end
+
+  describe '.fetch_ca_repository_certs_for_cert' do
+    context 'when the cert has a subject information access extension with Repository CA' do
+      it 'returns the certificate' do
+        certificate = certificates_in_collection(certificate_set, :type, :intermediate).first
+        sibling_cert = certificates_in_collection(certificate_set, :type, :intermediate).last
+
+        pkcs7_bundle = build_pkc7_bundle(sibling_cert.x509_cert)
+        stub_request(:get, 'http://example.com').to_return(body: pkcs7_bundle.to_der)
+
+        fetched_certs = described_class.fetch_ca_repository_certs_for_cert(certificate)
+
+        expect(fetched_certs).to eq([sibling_cert])
       end
     end
   end

--- a/spec/support/x509.rb
+++ b/spec/support/x509.rb
@@ -11,6 +11,12 @@ module X509Helpers
     false,
   ].freeze
 
+  SUBJECT_INFO_ACCESS_EXTENSION = [
+    'subjectInfoAccess',
+    'caRepository;URI:http://example.com/',
+    false,
+  ].freeze
+
   CA_CONFIG = OpenSSL::Config.parse(<<~SSL_CONFIG)
     oid_section = new_oids
      [ new_oids ]
@@ -182,6 +188,7 @@ module X509Helpers
       ['basicConstraints', 'CA:TRUE', true],
       ['keyUsage', 'keyCertSign, cRLSign', true],
       AUTHORITY_INFO_ACCESS_EXTENSION,
+      SUBJECT_INFO_ACCESS_EXTENSION,
       ['subjectKeyIdentifier', 'hash', false],
       ['authorityKeyIdentifier', 'keyid:always', false],
     ]


### PR DESCRIPTION
Adds a task which:
1. Accepts a key_id as an argument
2. Fetches that certificate's signing certificate
3. Checks if the signing certificate has an SIA extension with a CA Repository value
4. Downloads the certificates from the CA Repository
5. Selects certificates which are not the original certificate and have a similar subject
6. Prompts for which certificates to save
7. Saves selected certificates and tries to avoid name collisions by appending the expiry timestamp if a cert with that name exists

The task itself got pretty lengthy, and I moved some of the parts into existing classes where I could.

I added a link to https://fpki.idmanagement.gov/notifications/#notifications at the end of the task, I wasn't sure if there's a better way to check for expiring/replacement certs or what guidance should be included. For example, the expiring SSA cert that we had a replacement for also had a "matching" cert in the sample output below, but I'm not sure how to know if that's one we'd want to include?

Sample output:

```
mitchellehenke:identity-pki/ (mitchellhenke/find-expiring-cert-replacements-lg-3932*) $ rake certs:find_replacement\[CF:79:3C:ED:4D:BC:19:25:F2:45:69:4E:12:2F:9C:29:53:C9:A7:46\]
** [NewRelic] FATAL : Failed ERB processing configuration file. This is typically caused by a Ruby error in <% %> templating blocks in your newrelic.yml file.
** [NewRelic] FATAL : Missing required configuration key: "newrelic_license_key"
Signing Cert subject information access (SIA) extensions: {"CA Repository"=>["URI:http://pki.treasury.gov/root_sia.p7c"]}
Expiring Certificate:
  Expiration: 2022-08-28 14:17:17 UTC
  Subject: /C=US/O=U.S. Government/OU=Department of Veterans Affairs/OU=Certification Authorities/OU=Department of Veterans Affairs CA
  Issuer: /C=US/O=U.S. Government/OU=Department of the Treasury/OU=Certification Authorities/OU=US Treasury Root CA
  SHA1 Fingerpint: 519d3222a15eee034980fc0da727314f70af78c0
  Key ID: CF:79:3C:ED:4D:BC:19:25:F2:45:69:4E:12:2F:9C:29:53:C9:A7:46

Potential Replacement Certificates:
- Index: 0
  Expiration: 2029-06-22 13:53:22 UTC
  Subject: /C=US/O=U.S. Government/OU=Department of Veterans Affairs/OU=Certification Authorities/OU=Department of Veterans Affairs CA
  Issuer: /C=US/O=U.S. Government/OU=Department of the Treasury/OU=Certification Authorities/OU=US Treasury Root CA
  SHA1 Fingerpint: 76cc898f03eb0fc7e0877aac30a0c1340bb34879
  Key ID: DA:9C:B6:1F:FF:67:9D:47:91:0D:26:E7:29:66:14:65:97:E6:80:58
  In Certificate Store: false
- Index: 1
  Expiration: 2025-10-17 14:31:27 UTC
  Subject: /C=US/O=U.S. Government/OU=Department of Veterans Affairs/OU=Certification Authorities/OU=Department of Veterans Affairs CA
  Issuer: /C=US/O=U.S. Government/OU=Department of the Treasury/OU=Certification Authorities/OU=US Treasury Root CA
  SHA1 Fingerpint: e2edb0df1fe8068717a08e38741b5bc4c38029d0
  Key ID: 75:61:DA:1F:31:92:6E:2E:2A:64:5E:A3:65:19:85:65:80:E8:C7:2B
  In Certificate Store: true

Which cert(s) would you like to download? Use the format 1,2 if selecting multiple.
Press enter to skip
0

Writing certificate to ./config/certs/C=US, O=U.S. Government, OU=Department of Veterans Affairs, OU=Certification Authorities, OU=Department of Veterans Affairs CA.pem

Double check https://fpki.idmanagement.gov/notifications/#notifications for new and revoked certs
```