### PR TITLE
do not retry failures for OCSP (LG-4465)

### DIFF
--- a/app/services/ocsp_service.rb
+++ b/app/services/ocsp_service.rb
@@ -79,7 +79,7 @@ class OcspService
     end
   end
 
-  def make_single_http_request(uri, request, retries = 1)
+  def make_single_http_request(uri, request, retries = 0)
     make_single_http_request!(uri, request)
   rescue Errno::ECONNRESET, Timeout::Error => e
     retries -= 1


### PR DESCRIPTION
We should fall back to the certificate revocation list instead of hammering struggling web services