### PR TITLE
Refactor key rotation (LG-4464)

### DIFF
--- a/app/services/token_service.rb
+++ b/app/services/token_service.rb
@@ -3,12 +3,13 @@ class TokenService
   RANDOM_BYTES = 8
 
   class << self
-    def box(data)
+    def box(data, encryptor = nil)
+      encryptor = message_encryptor if encryptor.nil?
       # The RANDOM_BYTES are there to introduce some entropy since we aren't putting a lot
       # of information into the token. Ruby hashes serialize in the order the keys are
       # introduced, so the data is sandwiched between two random strings, though that is
       # sandwiched in non-random strings -- namely, `{` and `}` to open/close the JSON object.
-      message_encryptor.encrypt_and_sign(
+      encryptor.encrypt_and_sign(
         { r1: SecureRandom.base64(RANDOM_BYTES) }.
         merge(data).
         merge(r2: SecureRandom.base64(RANDOM_BYTES)).to_json,
@@ -78,21 +79,30 @@ class TokenService
     end
 
     def message_encryptor
-      @message_encryptor ||= begin
-        encryptor = ActiveSupport::MessageEncryptor.new(current_key, cipher: 'aes-256-gcm')
-        prior_keys.each { |key| encryptor.rotate key }
-        encryptor
+      return @message_encryptor if @message_encryptor
+
+      encryptor = ActiveSupport::MessageEncryptor.new(current_key, cipher: 'aes-256-gcm')
+      old_key = prior_key
+
+      if old_key
+        encryptor.rotate prior_key
       end
+
+      @message_encryptor = encryptor
     end
 
     def current_key
-      salt, pepper = key_salt_and_pepper
+      salt = IdentityConfig.store.token_encryption_key_salt
+      pepper = IdentityConfig.store.token_encryption_key_pepper
+
       truncate_key(ActiveSupport::KeyGenerator.new(pepper).generate_key(salt))
     end
 
-    def prior_keys
-      prior_key_signifiers.map do |ending|
-        old_salt, old_pepper = key_salt_and_pepper(ending)
+    def prior_key
+      old_salt = IdentityConfig.store.token_encryption_key_salt_old
+      old_pepper = IdentityConfig.store.token_encryption_key_pepper_old
+
+      if old_salt.present? && old_pepper.present?
         truncate_key(ActiveSupport::KeyGenerator.new(old_pepper).generate_key(old_salt))
       end
     end
@@ -102,31 +112,6 @@ class TokenService
     # that we manually truncate to 32 bytes
     def truncate_key(key)
       key[0...32]
-    end
-
-    def key_salt_and_pepper(ordinal = nil)
-      env = IdentityConfig.store
-      if ordinal
-        [env.send(:"token_encryption_key_salt_#{ordinal}!"),
-         env.send(:"token_encryption_key_pepper_#{ordinal}!")]
-      else
-        [env.token_encryption_key_salt,
-         env.token_encryption_key_pepper]
-      end
-    end
-
-    def prior_key_signifiers
-      salt_endings = gather_env_key_endings('token_encryption_key_salt_')
-      pepper_endings = gather_env_key_endings('token_encryption_key_pepper_')
-      (salt_endings & pepper_endings).sort_by(&:to_i)
-    end
-
-    def gather_env_key_endings(prefix)
-      range = prefix.length..-1
-      ENV.
-        keys.
-        select { |name| name.start_with?(prefix) }.
-        map { |name| name[range] }
     end
   end
 end

--- a/app/services/token_service.rb
+++ b/app/services/token_service.rb
@@ -4,7 +4,7 @@ class TokenService
 
   class << self
     def box(data, encryptor = nil)
-      encryptor = message_encryptor if encryptor.nil?
+      encryptor ||= message_encryptor
       # The RANDOM_BYTES are there to introduce some entropy since we aren't putting a lot
       # of information into the token. Ruby hashes serialize in the order the keys are
       # introduced, so the data is sandwiched between two random strings, though that is

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -26,6 +26,8 @@ nonce_bloom_filter_size: '100_000'
 nonce_bloom_filter_ttl: '300'
 piv_cac_verify_token_secret: ''
 secret_key_base: ''
+token_encryption_key_pepper_old: ''
+token_encryption_key_salt_old: ''
 
 # Trusted roots:
 # AD:0C:7A:75:5C:E5:F3:98:C4:79:98:0E:AC:28:FD:97:F4:E7:02:FC - Federal Common Policy
@@ -72,6 +74,8 @@ development:
   nonce_bloom_filter_enabled: 'true'
   token_encryption_key_salt: 23df6c812fb1ca9c17debee3a91aba30bc0e85c38b414ee59a9e3d3eb5ec5c0221e2558cac8a808375711cb1450a9db40b8aec74f147e4a3e15dc3c304f1b23e
   token_encryption_key_pepper: c6b4a68a3adf0ff2069d5240bb71532c7a8c0dbb77bba5f9070e2d8ab1ebcc918cc8d8cdbb04fa34ed71126fac3e02d9c85280ae0f7c42d22b678e3e5eb67cfe
+  token_encryption_key_salt_old: de+hXqHqjAIIKq+mgdbUdTfvOZQP7ya1MPsUKgy1/ueEl+Yw1w7ZzaObENqDD4DhrWD3zXUgI3UQm9ZISzOwpEk8lq/azWg8Pw9lPL1yBUR2easxcgbAl6gjPB+8fAFD
+  token_encryption_key_pepper_old: 1HkCB/IADCORWlBAUmeM9S+KBBv0eWzxJG8NM6+A1/f7K3KoVpa2HTED4pTNf8DGp834etYxOL+NdjvH88Lk1s5u401Hu3d3nPbnI11nWTfhaBCz6foOfS/3KGBd/8hz
   certificate_store_directory: 'config/certs'
 
 test:
@@ -82,6 +86,8 @@ test:
   nonce_bloom_filter_enabled: 'true'
   token_encryption_key_salt: 23df6c812fb1ca9c17debee3a91aba30bc0e85c38b414ee59a9e3d3eb5ec5c0221e2558cac8a808375711cb1450a9db40b8aec74f147e4a3e15dc3c304f1b23e
   token_encryption_key_pepper: c6b4a68a3adf0ff2069d5240bb71532c7a8c0dbb77bba5f9070e2d8ab1ebcc918cc8d8cdbb04fa34ed71126fac3e02d9c85280ae0f7c42d22b678e3e5eb67cfe
+  token_encryption_key_salt_old: de+hXqHqjAIIKq+mgdbUdTfvOZQP7ya1MPsUKgy1/ueEl+Yw1w7ZzaObENqDD4DhrWD3zXUgI3UQm9ZISzOwpEk8lq/azWg8Pw9lPL1yBUR2easxcgbAl6gjPB+8fAFD
+  token_encryption_key_pepper_old: 1HkCB/IADCORWlBAUmeM9S+KBBv0eWzxJG8NM6+A1/f7K3KoVpa2HTED4pTNf8DGp834etYxOL+NdjvH88Lk1s5u401Hu3d3nPbnI11nWTfhaBCz6foOfS/3KGBd/8hz
   certificate_store_directory: 'config/test-certs'
   ca_issuer_host_allow_list: 'uri1.example.com,uri2.example.com'
 

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -72,6 +72,8 @@ class IdentityConfig
     config.add(:secret_key_base)
     config.add(:token_encryption_key_pepper)
     config.add(:token_encryption_key_salt)
+    config.add(:token_encryption_key_pepper_old)
+    config.add(:token_encryption_key_salt_old)
     final_env = config.add(:trusted_ca_root_identifiers, type: :comma_separated_string_list)
 
     @store = Struct.new('IdentityConfig', *final_env.keys, keyword_init: true).

--- a/spec/services/token_service_spec.rb
+++ b/spec/services/token_service_spec.rb
@@ -8,4 +8,15 @@ RSpec.describe TokenService do
   it 'opens a boxed value' do
     expect(token_service.open(token_service.box(data))).to eq data
   end
+
+  it 'can open with data encrypted by old key' do
+    old_salt = IdentityConfig.store.token_encryption_key_salt_old
+    old_pepper = IdentityConfig.store.token_encryption_key_pepper_old
+
+    key = ActiveSupport::KeyGenerator.new(old_pepper).generate_key(old_salt, 32)
+    old_encryptor = ActiveSupport::MessageEncryptor.new(key, cipher: 'aes-256-gcm')
+    data_encypted_with_old_encryptor = TokenService.box(data, old_encryptor)
+
+    expect(token_service.open(data_encypted_with_old_encryptor)).to eq data
+  end
 end


### PR DESCRIPTION
Separated a more complicated part of #225 to make it easier to review. The previous implementation would dynamically check ENV keys that started with `token_encryption_key_salt_` and `token_encryption_key_pepper_` and use those as part of key rotation. This relied on Figaro writing ENV, which we want to move away from.

With the assumption that we will likely not need to be able to rotate through more than two keys at once, the TokenService was simplified to support rotating one key at a time through `token_encryption_key_salt_old` and `token_encryption_key_pepper_old`.