### PR TITLE
Remove binding_of_caller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ end
 
 group :development do
   gem 'better_errors', '>= 2.5.1'
-  gem 'binding_of_caller'
   gem 'brakeman', require: false
   gem 'bummr', require: false
   gem 'derailed', '>= 0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1053,8 +1053,6 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     bloomfilter-rb (2.1.1)
       redis
     brakeman (4.10.0)
@@ -1077,7 +1075,6 @@ GEM
     crass (1.0.6)
     daemons (1.3.1)
     database_cleaner (1.8.5)
-    debug_inspector (0.0.3)
     derailed (0.1.0)
       derailed_benchmarks
     derailed_benchmarks (1.8.1)
@@ -1330,7 +1327,6 @@ DEPENDENCIES
   aws-sdk
   axe-matchers (~> 1.3.4)
   better_errors (>= 2.5.1)
-  binding_of_caller
   bloomfilter-rb
   brakeman
   bullet (>= 6.0.2)


### PR DESCRIPTION
**Why**: It prevents the app from start in ruby 3. It looks like it was part of the `rails new` commit and I don't see anywhere that we use it.