### PR TITLE
Do not send unactionable OCSP errors to NewRelic

### DIFF
--- a/app/services/ocsp_service.rb
+++ b/app/services/ocsp_service.rb
@@ -112,6 +112,5 @@ class OcspService
       key_id: subject.key_id,
     }
     Rails.logger.warn("OCSP error: #{info.to_json}")
-    NewRelic::Agent.notice_error(exception)
   end
 end


### PR DESCRIPTION
OCSP errors happen frequently enough that it can set off error alerts during low volume times, but there isn't much we can do in response to the alert

The error is still logged by Rails, which keeps some level of visibility and record-keeping