### PR TITLE
add PIV cert metadata logging

### DIFF
--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -75,7 +75,7 @@ class IdentifyController < ApplicationController
       card_type: cert.card_type,
       valid_policies: cert.valid_policies?,
       valid: validation_result == 'valid',
-      error: validation_result == 'valid' ? validation_result : nil,
+      error: validation_result != 'valid' ? validation_result : nil,
     }.to_json)
 
     cert.token(nonce: nonce)

--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -65,6 +65,18 @@ class IdentifyController < ApplicationController
 
   def process_cert(raw_cert)
     cert = Certificate.new(OpenSSL::X509::Certificate.new(raw_cert))
+    validation_result = cert.validate_cert(is_leaf: true)
+
+    logger.info({
+      name: 'Certificate Processed',
+      signing_key_id: cert.signing_key_id,
+      key_id: cert.key_id,
+      issuer: cert.issuer.to_s,
+      card_type: cert.card_type,
+      valid_policies: cert.valid_policies?,
+      valid: validation_result == 'valid',
+      error: validation_result == 'valid' ? validation_result : nil,
+    }.to_json)
 
     cert.token(nonce: nonce)
   rescue OpenSSL::X509::CertificateError => error

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -166,6 +166,11 @@ class Certificate
     OpenSSL::Digest::SHA1.new(x509_cert.to_der).to_s
   end
 
+  def card_type
+    return 'cac' if trusted_dod_root?
+    'piv'
+  end
+
   private
 
   def get_extension(oid)
@@ -192,11 +197,6 @@ class Certificate
         card_type: card_type
       )
     )
-  end
-
-  def card_type
-    return 'cac' if trusted_dod_root?
-    'piv'
   end
 
   def trusted_dod_root?


### PR DESCRIPTION
Logs metadata when a connection is made with a PIV/CAC which could be useful to see usage rates across issuers, which issuers we could consider adding, etc.