### PR TITLE
skip logging issuer for self-signed certificates

### DIFF
--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -65,18 +65,8 @@ class IdentifyController < ApplicationController
 
   def process_cert(raw_cert)
     cert = Certificate.new(OpenSSL::X509::Certificate.new(raw_cert))
-    validation_result = cert.validate_cert(is_leaf: true)
 
-    logger.info({
-      name: 'Certificate Processed',
-      signing_key_id: cert.signing_key_id,
-      key_id: cert.key_id,
-      issuer: cert.issuer.to_s,
-      card_type: cert.card_type,
-      valid_policies: cert.valid_policies?,
-      valid: validation_result == 'valid',
-      error: validation_result != 'valid' ? validation_result : nil,
-    }.to_json)
+    log_certificate(cert)
 
     cert.token(nonce: nonce)
   rescue OpenSSL::X509::CertificateError => error
@@ -107,5 +97,26 @@ class IdentifyController < ApplicationController
   def allowed_referrer?(uri)
     allowed_host = IdentityConfig.store.identity_idp_host
     !allowed_host || uri.host == allowed_host
+  end
+
+  def log_certificate(cert)
+    validation_result = cert.validate_cert(is_leaf: true)
+
+    attributes = {
+      name: 'Certificate Processed',
+      signing_key_id: cert.signing_key_id,
+      key_id: cert.key_id,
+      issuer: cert.issuer.to_s,
+      card_type: cert.card_type,
+      valid_policies: cert.valid_policies?,
+      valid: validation_result == 'valid',
+      error: validation_result != 'valid' ? validation_result : nil,
+    }
+
+    if validation_result == 'self-signed cert'
+      attributes.delete(:issuer)
+    end
+
+    logger.info(attributes.to_json)
   end
 end


### PR DESCRIPTION
To avoid potentially logging certificate subjects, we can skip logging `issuer` for self-signed certs