### PR TITLE
Disable new relic log shipping

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,6 +1,10 @@
 production:
   agent_enabled: true
   app_name: pivcac.<%= Identity::Hostdata.env %>.<%= Identity::Hostdata.domain %>
+  # Application log forwarding should always be disabled
+  application_logging:
+    forwarding:
+      enabled: false
   host: gov-collector.newrelic.com
   audit_log:
     enabled: false


### PR DESCRIPTION
Following the changes to the IDP in https://github.com/18F/identity-idp/pull/6475, this disables New Relic log shipping.  We haven't updated to a version of the agent that would start shipping logs, but this ensures that we do not when we do update.