### PR TITLE
Remove Thin, Derailed dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ group :development, :test do
   gem 'bullet', '>= 6.0.2'
   gem 'pry-byebug'
   gem 'rspec-rails', '>= 3.8.3'
-  gem 'thin', '>= 1.8.0'
   gem 'rubocop', require: false
   gem 'rubocop-rails', '>= 2.19.0', require: false
   gem 'rubocop-performance', '~> 1.17', require: false
@@ -32,7 +31,6 @@ group :development do
   gem 'better_errors', '>= 2.5.1'
   gem 'brakeman', require: false
   gem 'bummr', require: false
-  gem 'derailed', '>= 0.1.0'
   gem 'guard-rspec', require: false
   gem 'overcommit', require: false
   gem 'rack-mini-profiler', '>= 1.0.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,6 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    benchmark-ips (2.8.3)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -131,21 +130,8 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    daemons (1.3.1)
     database_cleaner (1.8.5)
     date (3.3.3)
-    derailed (0.1.0)
-      derailed_benchmarks
-    derailed_benchmarks (1.8.1)
-      benchmark-ips (~> 2)
-      get_process_mem (~> 0)
-      heapy (~> 0)
-      memory_profiler (~> 0)
-      mini_histogram (>= 0.2.1)
-      rack (>= 1)
-      rake (> 10, < 14)
-      ruby-statistics (>= 2.1)
-      thor (>= 0.19, < 2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)
@@ -153,7 +139,6 @@ GEM
     dumb_delegator (0.8.1)
     equalizer (0.0.11)
     erubi (1.12.0)
-    eventmachine (1.2.7)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.1.0)
@@ -162,8 +147,6 @@ GEM
     fakefs (1.2.2)
     ffi (1.13.1)
     formatador (0.2.5)
-    get_process_mem (0.2.7)
-      ffi (~> 1.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     guard (2.16.2)
@@ -181,8 +164,6 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.0.1)
-    heapy (0.2.0)
-      thor
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -208,10 +189,8 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
-    memory_profiler (0.9.14)
     method_source (1.0.0)
     mini_cache (1.1.0)
-    mini_histogram (0.3.1)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.18.0)
@@ -349,7 +328,6 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
-    ruby-statistics (2.1.2)
     shellany (0.0.1)
     shoulda-matchers (3.1.3)
       activesupport (>= 4.0.0)
@@ -366,10 +344,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     stream (0.5.2)
-    thin (1.8.0)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (1.2.1)
     thread_safe (0.3.6)
     timecop (0.9.2)
@@ -406,7 +380,6 @@ DEPENDENCIES
   bullet (>= 6.0.2)
   bummr
   database_cleaner
-  derailed (>= 0.1.0)
   factory_bot_rails (>= 5.2.0)
   fakefs
   guard-rspec
@@ -431,7 +404,6 @@ DEPENDENCIES
   rubocop-rails (>= 2.19.0)
   shoulda-matchers (~> 3.1, >= 3.1.3)
   simplecov (>= 0.13.0)
-  thin (>= 1.8.0)
   timecop
   tzinfo-data
   webmock

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec thin start -p ${PORT:-8443} --ssl --ssl-key-file config/local-certs/server.key --ssl-cert-file config/local-certs/server.crt
+web: bundle exec rackup config.ru --host "ssl://${HOST:-localhost}:${PORT:-8443}?key=config/local-certs/server.key&cert=config/local-certs/server.crt"


### PR DESCRIPTION
Why?

- There's redundancy between having both "thin" and "puma" installed as dependencies
- These dependencies prevent me from running the application due to issues/crashes in transitive dependencies†
- Reduce maintenance overhead

† I was running into two issues on my M1 Mac after following instructions from README.md:

1. Errors from EventMachine, a dependency of Thin
   - "LoadError: dlopen(/.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/eventmachine-1.2.7/lib/rubyeventmachine.bundle, 0x0009): symbol not found in flat namespace (_SSL_get1_peer_certificate) - /.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/eventmachine-1.2.7/lib/rubyeventmachine.bundle"
2. Crashes from ffi, a dependency of Derailed
   - "/.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/ffi-1.13.1/lib/ffi/library.rb:275: [BUG] Bus Error at 0x00000001c05e41b0"