### PR TITLE
Updating scan step to handle null findings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -183,7 +183,7 @@ ecr-scan:
     - echo $SCAN_FINDINGS
     - >
       echo $SCAN_FINDINGS |
-      jq -r '
+      jq -r 'if (.imageScanFindings.findings | length > 0) then
       {
         "version": "15.0.4",
         "scan": {
@@ -248,7 +248,10 @@ ecr-scan:
             }
           }
         ]
-      }' > gl-container-scanning-report.json
+      }
+      else
+        "No findings"
+      end' > gl-container-scanning-report.json
   artifacts:
     paths: 
       - gl-container-scanning-report.json


### PR DESCRIPTION
## Summary
Adds null handling to the jq command to help avoid errors from, scans that don't have vulnerabilities. Looks like it works as expected, job with no findings that passed with the new if statement can be seen for related issue where this was found [HERE](https://gitlab.login.gov/lg/identity-devops/-/jobs/641281)