### PR TITLE
Updating to produce a blank scan instead of unparsable artifact

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -250,7 +250,32 @@ ecr-scan:
         ]
       }
       else
-        "No findings"
+      {
+        "version": "15.0.4",
+        "scan": {
+          "start_time": (now | strftime("%Y-%m-%dT%H:%M:%S")),
+          "end_time": (now | strftime("%Y-%m-%dT%H:%M:%S")),
+          "scanner": {
+            "id": "clair",
+            "name": "Amazon ECR Image Scan",
+            "version": "1.0.0",
+            "vendor": {
+              "name": "Amazon Web Services"
+            }
+          },
+          "analyzer": {
+            "id": "clair",
+            "name": "Amazon ECR Image Scan",
+            "version": "1.0.0",
+            "vendor": {
+              "name": "Amazon Web Services"
+            }
+          },
+          "status": "success",
+          "type": "container_scanning"
+        },
+        "vulnerabilities": []
+      }
       end' > gl-container-scanning-report.json
   artifacts:
     paths: 


### PR DESCRIPTION
## Summary
Updates the else statement of the jq scan parser to instead generate a blank scan so that an error isn't thrown in the `Vulnerability report` section of the Gitlab security dashboard.