### PR TITLE
Swap scan check from findings to enhancedFindings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -183,7 +183,7 @@ ecr-scan:
     - echo $SCAN_FINDINGS
     - >
       echo $SCAN_FINDINGS |
-      jq -r 'if (.imageScanFindings.findings | length > 0) then
+      jq -r 'if (.imageScanFindings.enhancedFindings | length > 0) then
       {
         "version": "15.0.4",
         "scan": {


### PR DESCRIPTION
## Summary
Swap the key to check from `.imageScanFindings.findings` to `imageScanFindings.enhancedFindings` to properly check length