### PR TITLE
Allow configuring logging to STDOUT with configuration variable (LG-10663)

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -21,6 +21,7 @@ database_username: ''
 database_sslmode: ''
 domain_name: ''
 identity_idp_host: 'localhost'
+log_to_stdout: false
 openssl_verify_enabled: 'true'
 newrelic_license_key : ''
 nonce_bloom_filter_hash_count: '4'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
+  if IdentityConfig.store.log_to_stdout
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/k8files/application.yml.default.docker
+++ b/k8files/application.yml.default.docker
@@ -22,3 +22,4 @@ production:
   piv_cac_verify_token_secret: 'a6ed2fb16320ae85a7a8e48f4b0eeb6afca5f1ac64af2a05a0c486df1c20b693987832a11f0910729f199b3ce5c7609fe6d580bed428d035ea8460990e38a382'
   identity_idp_host: ['env', 'IDP_HOST']
   domain_name: ['env', 'DOMAIN_NAME']
+  log_to_stdout: true

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -53,7 +53,6 @@ class IdentityConfig
     converted_value = CONVERTERS.fetch(type).call(value, options: options)
     raise "#{key} is required but is not present" if converted_value.nil?
 
-
     @key_types[key] = type
 
     @written_env[key] = converted_value
@@ -81,6 +80,7 @@ class IdentityConfig
     config.add(:http_open_timeout, type: :integer)
     config.add(:http_read_timeout, type: :integer)
     config.add(:identity_idp_host, type: :string)
+    config.add(:log_to_stdout, type: :boolean)
     config.add(:login_certificate_bundle_file, type: :string)
     config.add(:newrelic_license_key)
     config.add(:nonce_bloom_filter_enabled, type: :boolean)


### PR DESCRIPTION
This PR adds a configuration variable to log to STDOUT similar to what we have in the [IDP](https://github.com/18F/identity-idp/blob/a7dd13c6077e3b3ab02bd9625aba82a8624f5ea6/config/application.yml.default#L195). It also enables it for review applications.

[Ticket](https://cm-jira.usa.gov/browse/LG-10663)