### PR TITLE
Fix deprecated OpenSSL::Digest and File method usage

### DIFF
--- a/app/services/ocsp_service.rb
+++ b/app/services/ocsp_service.rb
@@ -43,7 +43,7 @@ class OcspService
   def certificate_id
     @certificate_id ||= begin
       issuer = authority.certificate
-      digest = OpenSSL::Digest::SHA1.new
+      digest = OpenSSL::Digest.new('SHA1')
       OpenSSL::OCSP::CertificateId.new(subject.x509_cert, issuer.x509_cert, digest)
     end
   end

--- a/bin/fast_setup
+++ b/bin/fast_setup
@@ -31,7 +31,7 @@ chdir APP_ROOT do
 
   puts '== Setting up config overrides =='
   default_application_yml = { 'development' => { 'config_key' => nil } }
-  File.write('config/application.yml', default_application_yml.to_yaml) unless File.exists?('config/application.yml')
+  File.write('config/application.yml', default_application_yml.to_yaml) unless File.exist?('config/application.yml')
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'

--- a/bin/setup
+++ b/bin/setup
@@ -32,7 +32,7 @@ chdir APP_ROOT do
 
   puts '== Setting up config overrides =='
   default_application_yml = { 'development' => { 'config_key' => nil } }
-  File.write('config/application.yml', default_application_yml.to_yaml) unless File.exists?('config/application.yml')
+  File.write('config/application.yml', default_application_yml.to_yaml) unless File.exist?('config/application.yml')
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Certificate do
       leaf_certs.each do |cert|
         issuer = CertificateStore.instance[cert.signing_key_id]
         certificate_id = OpenSSL::OCSP::CertificateId.new(
-          cert.x509_cert, issuer.x509_cert, OpenSSL::Digest::SHA1.new
+          cert.x509_cert, issuer.x509_cert, OpenSSL::Digest.new('SHA1')
         )
         mapping[certificate_id] = {
           subject: cert,

--- a/spec/services/certificate_store_spec.rb
+++ b/spec/services/certificate_store_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe CertificateStore do
       leaf_certs.each do |cert|
         issuer = CertificateStore.instance[cert.signing_key_id]
         certificate_id = OpenSSL::OCSP::CertificateId.new(
-          cert.x509_cert, issuer.x509_cert, OpenSSL::Digest::SHA1.new
+          cert.x509_cert, issuer.x509_cert, OpenSSL::Digest.new('SHA1')
         )
         mapping[certificate_id] = {
           subject: cert,

--- a/spec/support/x509.rb
+++ b/spec/support/x509.rb
@@ -51,7 +51,7 @@ module X509Helpers
       revocation.add_extension(ext)
       crl.add_revoked(revocation)
     end
-    crl.sign(root_key, OpenSSL::Digest::SHA256.new)
+    crl.sign(root_key, OpenSSL::Digest.new('SHA256'))
     crl
   end
 
@@ -161,7 +161,7 @@ module X509Helpers
     end
 
     add_certificate_extensions(root_ca, root_ca, *extensions)
-    root_ca.sign(root_key, OpenSSL::Digest::SHA256.new)
+    root_ca.sign(root_key, OpenSSL::Digest.new('SHA256'))
     [root_ca, root_key]
   end
 
@@ -210,7 +210,7 @@ module X509Helpers
     end
 
     add_certificate_extensions(cert, root_ca, *extensions)
-    cert.sign(root_key, OpenSSL::Digest::SHA256.new)
+    cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
     [cert, key]
   end
 
@@ -265,7 +265,7 @@ module X509Helpers
     end
 
     add_certificate_extensions(cert, root_ca, *extensions)
-    cert.sign(root_key, OpenSSL::Digest::SHA256.new)
+    cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
     cert
   end
 
@@ -287,7 +287,7 @@ module X509Helpers
         **root_options
       )
       root_cert_id = OpenSSL::OCSP::CertificateId.new(
-        root, root, OpenSSL::Digest::SHA1.new
+        root, root, OpenSSL::Digest.new('SHA1')
       )
       root_certs << {
         type: :root,
@@ -310,7 +310,7 @@ module X509Helpers
           **intermediate_options
         )
         intermediate_cert_id = OpenSSL::OCSP::CertificateId.new(
-          intermediate, root, OpenSSL::Digest::SHA1.new
+          intermediate, root, OpenSSL::Digest.new('SHA1')
         )
         intermediate_certs << {
           type: :intermediate,
@@ -336,7 +336,7 @@ module X509Helpers
             **leaf_options
           )
           leaf_cert_id = OpenSSL::OCSP::CertificateId.new(
-            leaf, intermediate, OpenSSL::Digest::SHA1.new
+            leaf, intermediate, OpenSSL::Digest.new('SHA1')
           )
           leaf_certs << {
             type: :leaf,


### PR DESCRIPTION
Our usage of these `OpenSSL::Digest` and `File` calls have been deprecated and this PR replaces them with their updated definitions