### PR TITLE
Hardcoding main container tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ build-pivcac-image:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       variables:
-        BRANCH_TAGGING_STRING: "--destination ${ECR_REGISTRY}/identity-pivcac/review:${CI_DEFAULT_BRANCH}"
+        BRANCH_TAGGING_STRING: "--destination ${ECR_REGISTRY}/identity-pivcac/review:main"
     - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
     - if: $CI_PIPELINE_SOURCE != "merge_request_event"
       when: never


### PR DESCRIPTION
Production GitLab appears to be protecting the CI_DEFAULT_BRANCH variable and is causing the main container to not get tagged properly. Switching to hardcoded container tag to ensure the tagging occurs.