### PR TITLE
update nginx conf file to redirect access and error logs to stdout

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@
 variables:
   ECR_REGISTRY: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
   IDP_WORKER_IMAGE_TAG: 'main'
-  PIVCAC_CI_SHA: 'sha256:831676006259d22aee1e7fc36331bb90ba8bbca90aee8efdb8bfb0299b4f9635'
+  PIVCAC_CI_SHA: 'sha256:1b280037c653d00685e10890afe01f83c943ed409a810c398ee9dcb90cdfbd11'
   CI: 'true'
 
 default:

--- a/k8files/nginx.conf
+++ b/k8files/nginx.conf
@@ -91,11 +91,14 @@ http {
         '"tls_protocol": "$ssl_protocol", '
         '"tls_cipher": "$ssl_cipher", '
         '"uri_path": "$uri", '
-        '"uri_query": "$query_string"'
+        '"uri_query": "$query_string",'
+        '"log_filename": "nginx_access.log"'
     '}';
 
   access_log /var/log/nginx/access.log kv;
+  access_log /dev/stdout kv;
   error_log  /var/log/nginx/error.log info;
+  error_log  /dev/stdout info;
 
   # Get $status_reason variable, a human readable version of $status
   include status-map.conf;


### PR DESCRIPTION
This is to capture additional IDP and PIV/CAC logs and send them to CloudWatch
https://cm-jira.usa.gov/browse/LG-10663