### PR TITLE
Add bootsnap to improve boot speed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'newrelic_rpm', '~> 8.0'
 gem 'pg'
 gem 'pry-rails'
 gem 'puma'
+gem 'bootsnap', '~> 1.0', require: false
 gem 'redacted_struct', '~> 1.0'
 gem 'rgl'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
       rack (>= 0.9.0)
     bloomfilter-rb (2.1.1)
       redis
+    bootsnap (1.17.0)
+      msgpack (~> 1.2)
     brakeman (6.0.1)
     builder (3.2.4)
     bullet (7.0.7)
@@ -203,6 +205,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
     minitest (5.19.0)
+    msgpack (1.7.2)
     nenv (0.3.0)
     net-imap (0.3.7)
       date
@@ -383,6 +386,7 @@ DEPENDENCIES
   axe-matchers (~> 1.3.4)
   better_errors (>= 2.5.1)
   bloomfilter-rb
+  bootsnap (~> 1.0)
   brakeman
   bullet (~> 7.0)
   bummr

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' if ENV['ENABLE_BOOTSNAP'] != 'false'


### PR DESCRIPTION
We added bootsnap to the IDP in https://github.com/18F/identity-idp/pull/4017 / https://github.com/18F/identity-idp/pull/5444, and we can add it here to so that we can boot faster.