### PR TITLE
Updating to always for images that reference main to prevent staleness

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -228,7 +228,7 @@ review-app:
         {"name": "LOGIN_HOST_ROLE", "value": "idp" },
         {"name": "LOGIN_SKIP_REMOTE_CONFIG", "value": "true" },
         {"name": "PIV_CAC_SERVICE_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"},
-        {"name": "PIV_CAC_VERIFY_TOKEN_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"}
+        {"name": "PIV_CAC_VERIFY_TOKEN_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"},
         {"name": "DASHBOARD_URL", "value": ""}
       ]
       EOF

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,6 +205,7 @@ review-app:
     - |-
       export IDP_ENV=$(cat <<EOF
       [
+        {"name": "KUBERNETES_REVIEW_APP", "value": "true"},
         {"name": "POSTGRES_SSLMODE", "value": "prefer"},
         {"name": "POSTGRES_NAME", "value": "idp"},
         {"name": "POSTGRES_HOST","value": "$CI_ENVIRONMENT_SLUG-login-chart-pg.review-apps"},

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,6 +229,7 @@ review-app:
         {"name": "LOGIN_SKIP_REMOTE_CONFIG", "value": "true" },
         {"name": "PIV_CAC_SERVICE_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"},
         {"name": "PIV_CAC_VERIFY_TOKEN_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"}
+        {"name": "DASHBOARD_URL", "value": ""}
       ]
       EOF
       )

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,7 +229,7 @@ review-app:
         {"name": "LOGIN_SKIP_REMOTE_CONFIG", "value": "true" },
         {"name": "PIV_CAC_SERVICE_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"},
         {"name": "PIV_CAC_VERIFY_TOKEN_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"},
-        {"name": "DASHBOARD_URL", "value": ""}
+        {"name": "DASHBOARD_URL", "value": "https://$CI_ENVIRONMENT_SLUG.review-app.identitysandbox.gov"}
       ]
       EOF
       )

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,8 +269,10 @@ review-app:
       --set pivcac.image.tag="${CI_COMMIT_SHA}"
       --set idp.image.repository="${ECR_REGISTRY}/identity-idp/review"
       --set idp.image.tag="${IDP_WORKER_IMAGE_TAG}"
+      --set idp.image.pullPolicy="Always" \
       --set worker.image.repository="${ECR_REGISTRY}/identity-idp/review"
       --set worker.image.tag="${IDP_WORKER_IMAGE_TAG}"
+      --set worker.image.pullPolicy="Always" \
       --set-json pivcac.env="$PIVCAC_ENV"
       --set-json idp.env="$IDP_ENV"
       --set-json worker.env="$WORKER_ENV"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,10 +269,10 @@ review-app:
       --set pivcac.image.tag="${CI_COMMIT_SHA}"
       --set idp.image.repository="${ECR_REGISTRY}/identity-idp/review"
       --set idp.image.tag="${IDP_WORKER_IMAGE_TAG}"
-      --set idp.image.pullPolicy="Always" \
+      --set idp.image.pullPolicy="Always"
       --set worker.image.repository="${ECR_REGISTRY}/identity-idp/review"
       --set worker.image.tag="${IDP_WORKER_IMAGE_TAG}"
-      --set worker.image.pullPolicy="Always" \
+      --set worker.image.pullPolicy="Always"
       --set-json pivcac.env="$PIVCAC_ENV"
       --set-json idp.env="$IDP_ENV"
       --set-json worker.env="$WORKER_ENV"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,6 +235,7 @@ review-app:
     - |-
       export WORKER_ENV=$(cat <<EOF
       [
+        {"name": "KUBERNETES_REVIEW_APP", "value": "true"},
         {"name": "POSTGRES_SSLMODE", "value": "prefer"},
         {"name": "POSTGRES_NAME", "value": "idp"},
         {"name": "POSTGRES_HOST", "value": "$CI_ENVIRONMENT_SLUG-login-chart-pg.review-apps"},


### PR DESCRIPTION
# Summary
Swaps from the default pull policy of `IfNotPresent` to `Always` for images that are referencing `main` to prevent stale containers from hanging around and being used. Also add the missing environment variable `KUBERNETES_REVIEW_APP` which  was causing some wrong behavior when trying to launch the review-app.