### PR TITLE
Expand troubleshooting advice for OpenSSL 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ PIV/CAC support for login.gov.
 #### Dependencies
 
 - Ruby 3.0
-- OpenSSL 1.1
-- [Postgresql](http://www.postgresql.org/download/)
+- OpenSSL 1.1 (see [troubleshooting notes](#troubleshooting-openssl-or-certificate-validation-errors))
+- [PostgreSQL](http://www.postgresql.org/download/)
 
 #### Setting up and running the app
 
@@ -96,11 +96,24 @@ Most of the root certificate management is handled by `bin/setup` but there are 
 
 4. Under the "Trust" section, select "Always Trust" for the top-level "When using this certificate" dropdown
 
-#### Troubleshooting Certificate invalid Error
-If you are attempting to register or sign in with your PIV locally and you get errors saying your Certificate is invalid, Ensure that you have OpenSSl 1.1 installed and running for ruby.
-To check run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.
+#### Troubleshooting OpenSSL or certificate validation errors
 
-If you notice that the version is not valid you will need to install openssl@1.1 and reinstall ruby with the openssl directory pointing to the correct version.
+Errors commonly occur due to a mismatch in the expected version of OpenSSL:
+
+- Trying to register or authenticate with your PIV locally produces errors saying your certificate is invalid
+- Running certificate Rake tasks produces Ruby errors
+
+If you encounter errors, ensure that you have OpenSSL 1.1 installed, including bindings for your Ruby installation.
+
+To check, run: `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`
+
+If the version is anything other than OpenSSL 1.1, you will need to install OpenSSL 1.1 and reinstall Ruby with the OpenSSL directory pointing to the correct version.
+
+If you have [Homebrew](https://brew.sh/) available and use [`rbenv`](https://github.com/rbenv/rbenv) to manage your Ruby installation, you can run the following command to reinstall the project's version of Ruby with OpenSSL 1.1:
+
+```
+RUBY_CONFIGURE_OPTS=--with-openssl-dir=$(brew --prefix openssl@1.1) rbenv install
+```
 
 #### Cleaning up the root SSL certificate
 


### PR DESCRIPTION
Updates README.md to try to further highlight problems resulting from OpenSSL version mismatches:

- Include a link in the top-level dependencies list to troubleshooting advice
- Emphasize that this is a common source of errors
- Include additional example for Ruby errors from certificate Rake tasks (what I was encountering yesterday with #435)
- Add command for reinstalling with Homebrew and rbenv