### PR TITLE
Install dependencies in setup with Homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@
 
 /postgres-data
 
+# Avoid hard-pinning Homebrew dependencies
+Brewfile.lock.json
+
 # Ignore the files generated during setup
 /config/local-certs/rootCA.key
 /config/local-certs/rootCA.pem

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,3 @@
+brew 'nginx'
+brew 'postgresql@14'
+brew 'openssl@1.1'

--- a/README.md
+++ b/README.md
@@ -10,77 +10,23 @@ PIV/CAC support for login.gov.
 - Ruby 3.0
 - OpenSSL 1.1 (see [troubleshooting notes](#troubleshooting-openssl-or-certificate-validation-errors))
 - [PostgreSQL](http://www.postgresql.org/download/)
+- Nginx
 
 #### Setting up and running the app
 
-1. Make sure you have a working development environment with all the
-  [dependencies](#dependencies) installed. On OS X, the easiest way
-  to set up a development environment is by running our [Laptop]
-  script. The script will install all of this project's dependencies.
+Run the following command to set up your local environment:
 
-  If using rbenv, you may need to alias your specific installed ruby
-  version to the more generic version found in the `.ruby-version` file.
-  To do this, use [`rbenv-aliases`](https://github.com/tpope/rbenv-aliases):
+```
+$ make setup
+```
 
-  ```
-  git clone git://github.com/tpope/rbenv-aliases.git "$(rbenv root)/plugins/rbenv-aliases" # install rbenv-aliases per its documentation
+The first time, it will prompt for a passphrase for the root certificate. You can put anything as long as you remember it, it's just for development. You will also want to make sure to [trust the root SSL certificate](#trust-the-root-ssl-certificate)
 
-  rbenv alias 3.0 3.0.6 # create the version alias
-  ```
+Run the app server with:
 
-1. Make sure you have Nginx installed.
-
-  ```
-  $ brew install nginx
-  ```
-
-1. Make sure Postgres is running.
-
-  For example, if you've installed the laptop script on OS X, you can start the services like this:
-
-  ```
-  $ brew services start postgresql
-  ```
-
-1. Create the development and test databases:
-
-  ```
-  $ psql -c "CREATE DATABASE identity_pki_dev;"
-  $ psql -c "CREATE DATABASE identity_pki_test;"
-  ```
-
-1. Run the following command to set up the environment
-
-  - The first time, it will prompt for a passphrase for the root certificate. You can put anything as long as you remember it, it's just for development. To keep it simple, try `salty pickles`.
-
-  - Make sure to [trust the root SSL certificate](#trust-the-root-ssl-certificate)
-
-  ```
-  $ make setup
-  ```
-
-  This command copies sample configuration files, installs required gems
-  and sets up the database.
-
-1. Run the app server with:
-
-  ```
-  $ make run
-  ```
-
-Before making any commits, you'll also need to run `overcommit --sign.`
-This verifies that the commit hooks defined in our `.overcommit.yml` file are
-the ones we expect. Each change to the `.overcommit.yml` file, including the initial install
-performed in the setup script, will necessitate a new signature.
-
-For more information, see [overcommit](https://github.com/brigade/overcommit)
-
-If you want to measure the app's performance in development, set the
-`rack_mini_profiler` option to `'on'` in `config/application.yml` and
-restart the server. See the [rack_mini_profiler] gem for more details.
-
-[Laptop]: https://github.com/18F/laptop
-[rack_mini_profiler]: https://github.com/MiniProfiler/rack-mini-profiler
+```
+$ make run
+```
 
 ### Running the app locally with the IDP
 

--- a/bin/setup
+++ b/bin/setup
@@ -35,6 +35,8 @@ chdir APP_ROOT do
   File.write('config/application.yml', default_application_yml.to_yaml) unless File.exist?('config/application.yml')
 
   puts '== Installing dependencies =='
+  brew_installed = system "brew -v 2>&1"
+  run "brew bundle" if brew_installed
   system! 'gem install bundler --conservative'
   run 'gem install foreman --conservative && gem update foreman'
   system('bundle check') || system!('bundle install --without deploy production')


### PR DESCRIPTION
## 🛠 Summary of changes

This adds a Brewfile listing required dependencies and calls it as part of the `bin/setup` (`make setup`) task, [similar to what we do in the IdP](https://github.com/18F/identity-idp/blob/f4feb472a6747ef04c637b4620940157269ea6e6/bin/setup#L53-L54).

This should make the setup process easier and avoid issues where the developer may not have the required dependencies installed. I encountered this myself when seeing nginx errors, not realizing that nginx was a dependency because it wasn't listed as one, and was only referenced as a requirement later in the README.

This removes quite a bit of detail from the README, with the hoped expectation these are accounted for in `make setup`, and wanting to keep the instructions simple and direct. Alternatively, we could add some of this detail back in other sections of the README if needed.

## 📜 Testing Plan

Run `make setup`

Ideally you'd be starting fresh and can confirm that you can follow the instructions successfully to a running application.