### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!-- Uncomment and update the sections you need for your PR! -->
+
+<!--
+## 🎫 Ticket
+
+Link to the relevant ticket.
+-->
+
+<!--
+## 🛠 Summary of changes
+
+Write a brief description of what you changed.
+-->
+
+<!--
+## 📜 Testing Plan
+
+Provide a list of steps to confirm the changes.
+
+1. Step 1
+2. Step 2
+3. Step 3
+-->
+
+<!--
+## 👀 Screenshots
+
+If relevant, include a screenshot or screen capture of the changes.
+-->


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a [GitHub pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to the repository.

**Why?**

- So that a prospective contributor understands what details are expected to be included in a pull request
- For consistency across Login.gov projects (see [identity-idp](https://github.com/18F/identity-idp/blob/main/.github/pull_request_template.md), [identity-site](https://github.com/18F/identity-site/blob/main/.github/pull_request_template.md), [identity-design-system](https://github.com/18F/identity-design-system/blob/main/.github/pull_request_template.md))