### PR TITLE
Sync Ruby version in README to ruby-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PIV/CAC support for login.gov.
 
 #### Dependencies
 
-- Ruby 3.0
+- Ruby 3.2
 - OpenSSL 1.1 (see [troubleshooting notes](#troubleshooting-openssl-or-certificate-validation-errors))
 - [PostgreSQL](http://www.postgresql.org/download/)
 - Nginx


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the version number in the README.md to match what's in `.ruby-version`:

https://github.com/18F/identity-pki/blob/8a0072dd484b896a7f479c453d1364e5f143e27a/.ruby-version#L1