### PR TITLE
Allow specifying days for expiration in print_expiring task and set it to zero in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,7 +133,7 @@ check_expiring_certificates:
   script:
     - *bundle_install
     - bundle exec rake db:setup --trace
-    - bundle exec rake certs:print_expiring
+    - bundle exec rake certs:print_expiring[0]
 
 # Build a container image async, and don't block CI tests
 # Cache intermediate images for 1 week (168 hours)

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -18,8 +18,9 @@ namespace :certs do
   end
 
   desc 'Print expiring certs'
-  task print_expiring: :environment do
-    deadline = 30.days.from_now
+  task :print_expiring, [:deadline_days] => [:environment] do |t, args|
+    args.with_defaults(:deadline_days => 30)
+    deadline = args[:deadline_days].to_i.days.from_now
 
     cert_store = CertificateStore.instance
     cert_store.load_certs!(dir: Rails.root.join('config/certs'))


### PR DESCRIPTION
## 🛠 Summary of changes

We don't necessarily want to fail on a cert that expires in the future, as it is still valid until then. We still have alerts based on the health check endpoint which we can rely on for notification for soon-to-expire certificates.

This PR changes it so that CI only fails if a cert is expired.


<!--
## 📜 Testing Plan

Provide a list of steps to confirm the changes.

1. Step 1
2. Step 2
3. Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.
-->
