### PR TITLE
Deploy RC 69 to production

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!-- Uncomment and update the sections you need for your PR! -->
+
+<!--
+## 🎫 Ticket
+
+Link to the relevant ticket.
+-->
+
+<!--
+## 🛠 Summary of changes
+
+Write a brief description of what you changed.
+-->
+
+<!--
+## 📜 Testing Plan
+
+Provide a list of steps to confirm the changes.
+
+1. Step 1
+2. Step 2
+3. Step 3
+-->
+
+<!--
+## 👀 Screenshots
+
+If relevant, include a screenshot or screen capture of the changes.
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@
 
 /postgres-data
 
+# Avoid hard-pinning Homebrew dependencies
+Brewfile.lock.json
+
 # Ignore the files generated during setup
 /config/local-certs/rootCA.key
 /config/local-certs/rootCA.pem

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,7 +133,7 @@ check_expiring_certificates:
   script:
     - *bundle_install
     - bundle exec rake db:setup --trace
-    - bundle exec rake certs:print_expiring
+    - bundle exec rake certs:print_expiring[0]
 
 # Build a container image async, and don't block CI tests
 # Cache intermediate images for 1 week (168 hours)

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,3 @@
+brew 'nginx'
+brew 'postgresql@14'
+brew 'openssl@1.1'

--- a/README.md
+++ b/README.md
@@ -10,77 +10,23 @@ PIV/CAC support for login.gov.
 - Ruby 3.0
 - OpenSSL 1.1 (see [troubleshooting notes](#troubleshooting-openssl-or-certificate-validation-errors))
 - [PostgreSQL](http://www.postgresql.org/download/)
+- Nginx
 
 #### Setting up and running the app
 
-1. Make sure you have a working development environment with all the
-  [dependencies](#dependencies) installed. On OS X, the easiest way
-  to set up a development environment is by running our [Laptop]
-  script. The script will install all of this project's dependencies.
+Run the following command to set up your local environment:
 
-  If using rbenv, you may need to alias your specific installed ruby
-  version to the more generic version found in the `.ruby-version` file.
-  To do this, use [`rbenv-aliases`](https://github.com/tpope/rbenv-aliases):
+```
+$ make setup
+```
 
-  ```
-  git clone git://github.com/tpope/rbenv-aliases.git "$(rbenv root)/plugins/rbenv-aliases" # install rbenv-aliases per its documentation
+The first time, it will prompt for a passphrase for the root certificate. You can put anything as long as you remember it, it's just for development. You will also want to make sure to [trust the root SSL certificate](#trust-the-root-ssl-certificate)
 
-  rbenv alias 3.0 3.0.6 # create the version alias
-  ```
+Run the app server with:
 
-1. Make sure you have Nginx installed.
-
-  ```
-  $ brew install nginx
-  ```
-
-1. Make sure Postgres is running.
-
-  For example, if you've installed the laptop script on OS X, you can start the services like this:
-
-  ```
-  $ brew services start postgresql
-  ```
-
-1. Create the development and test databases:
-
-  ```
-  $ psql -c "CREATE DATABASE identity_pki_dev;"
-  $ psql -c "CREATE DATABASE identity_pki_test;"
-  ```
-
-1. Run the following command to set up the environment
-
-  - The first time, it will prompt for a passphrase for the root certificate. You can put anything as long as you remember it, it's just for development. To keep it simple, try `salty pickles`.
-
-  - Make sure to [trust the root SSL certificate](#trust-the-root-ssl-certificate)
-
-  ```
-  $ make setup
-  ```
-
-  This command copies sample configuration files, installs required gems
-  and sets up the database.
-
-1. Run the app server with:
-
-  ```
-  $ make run
-  ```
-
-Before making any commits, you'll also need to run `overcommit --sign.`
-This verifies that the commit hooks defined in our `.overcommit.yml` file are
-the ones we expect. Each change to the `.overcommit.yml` file, including the initial install
-performed in the setup script, will necessitate a new signature.
-
-For more information, see [overcommit](https://github.com/brigade/overcommit)
-
-If you want to measure the app's performance in development, set the
-`rack_mini_profiler` option to `'on'` in `config/application.yml` and
-restart the server. See the [rack_mini_profiler] gem for more details.
-
-[Laptop]: https://github.com/18F/laptop
-[rack_mini_profiler]: https://github.com/MiniProfiler/rack-mini-profiler
+```
+$ make run
+```
 
 ### Running the app locally with the IDP
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ Most of the root certificate management is handled by `bin/setup` but there are 
 
 1. Open the Keychain Access app
 
-2. Go to "Certificates" bottom left section
+2. Within your default keychain, search for the certificate "**identity-pki Development Certificate**"
 
-3. Find the cert named "**identity-pki Development Certificate**" open its settings
+3. Double-click the certificate to view its details
 
-4. Under the "Trust" section, select "Always Trust" for the top-level "When using this certificate" dropdown
+4. Expand the "Trust" section and select "Always Trust" for the top-level "When using this certificate" dropdown
+
+5. Close the details to save your changes. You'll be prompted to enter your password or PIN to confirm the changes.
 
 #### Troubleshooting OpenSSL or certificate validation errors
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ PIV/CAC support for login.gov.
 #### Dependencies
 
 - Ruby 3.0
-- OpenSSL 1.1
-- [Postgresql](http://www.postgresql.org/download/)
+- OpenSSL 1.1 (see [troubleshooting notes](#troubleshooting-openssl-or-certificate-validation-errors))
+- [PostgreSQL](http://www.postgresql.org/download/)
 
 #### Setting up and running the app
 
@@ -96,11 +96,24 @@ Most of the root certificate management is handled by `bin/setup` but there are 
 
 4. Under the "Trust" section, select "Always Trust" for the top-level "When using this certificate" dropdown
 
-#### Troubleshooting Certificate invalid Error
-If you are attempting to register or sign in with your PIV locally and you get errors saying your Certificate is invalid, Ensure that you have OpenSSl 1.1 installed and running for ruby.
-To check run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.
+#### Troubleshooting OpenSSL or certificate validation errors
 
-If you notice that the version is not valid you will need to install openssl@1.1 and reinstall ruby with the openssl directory pointing to the correct version.
+Errors commonly occur due to a mismatch in the expected version of OpenSSL:
+
+- Trying to register or authenticate with your PIV locally produces errors saying your certificate is invalid
+- Running certificate Rake tasks produces Ruby errors
+
+If you encounter errors, ensure that you have OpenSSL 1.1 installed, including bindings for your Ruby installation.
+
+To check, run: `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`
+
+If the version is anything other than OpenSSL 1.1, you will need to install OpenSSL 1.1 and reinstall Ruby with the OpenSSL directory pointing to the correct version.
+
+If you have [Homebrew](https://brew.sh/) available and use [`rbenv`](https://github.com/rbenv/rbenv) to manage your Ruby installation, you can run the following command to reinstall the project's version of Ruby with OpenSSL 1.1:
+
+```
+RUBY_CONFIGURE_OPTS=--with-openssl-dir=$(brew --prefix openssl@1.1) rbenv install
+```
 
 #### Cleaning up the root SSL certificate
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PIV/CAC support for login.gov.
 
 #### Dependencies
 
-- Ruby 3.0
+- Ruby 3.2
 - OpenSSL 1.1 (see [troubleshooting notes](#troubleshooting-openssl-or-certificate-validation-errors))
 - [PostgreSQL](http://www.postgresql.org/download/)
 - Nginx

--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -121,6 +121,9 @@ class IdentifyController < ApplicationController
     }
 
     attributes.delete(:issuer) if validation_result == 'self-signed cert'
+    if valid
+      attributes[:matched_policy_oids] = cert.matched_policy_oids.map { |oid| [oid, true] }.to_h
+    end
 
     # Log certificate if it fails either OpenSSL validation, but passes our current validation or vice versa
     if valid != login_certs_openssl_result[:valid] || valid != ficam_certs_openssl_result[:valid]

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -14,7 +14,7 @@ class Certificate
   def_delegators :x509_cert, :not_before, :not_after, :subject, :issuer, :verify,
                  :public_key, :serial, :to_text
 
-  def_delegators :@cert_policies, :allowed_by_policy?, :critical_policies_recognized?
+  def_delegators :@cert_policies, :allowed_by_policy?, :critical_policies_recognized?, :matched_policy_oids
 
   def trusted_root?
     CertificateStore.trusted_ca_root_identifiers.include?(key_id)

--- a/app/policies/certificate_policies.rb
+++ b/app/policies/certificate_policies.rb
@@ -27,10 +27,14 @@ class CertificatePolicies
     # otherwise, we want to allow it for now, but log the cert so we can see what policies are
     # coming up
     # This policy check is only on the leaf certificate - not used by CAs
+    matched_policy_oids.any?
+  end
+
+  def matched_policy_oids
     mapping = PolicyMappingService.new(@certificate).call
     expected_policies = required_policies
     cert_policies = policies.map { |policy| mapping[policy] }
-    (cert_policies & expected_policies).any?
+    (cert_policies & expected_policies)
   end
 
   def policies

--- a/bin/setup
+++ b/bin/setup
@@ -35,6 +35,8 @@ chdir APP_ROOT do
   File.write('config/application.yml', default_application_yml.to_yaml) unless File.exist?('config/application.yml')
 
   puts '== Installing dependencies =='
+  brew_installed = system "brew -v 2>&1"
+  run "brew bundle" if brew_installed
   system! 'gem install bundler --conservative'
   run 'gem install foreman --conservative && gem update foreman'
   system('bundle check') || system!('bundle install --without deploy production')

--- a/k8.Dockerfile
+++ b/k8.Dockerfile
@@ -21,10 +21,11 @@ ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \    
     build-essential \
     cron \
     curl \    
+    gettext-base \
     git-core \
     tar \ 
     unzip \
@@ -95,7 +96,10 @@ RUN ln -s /usr/local/nginx/nginx /usr/local/sbin/nginx; \
 COPY --chmod=644 ./k8files/status-map.conf /opt/nginx/conf/
 COPY --chmod=644 ./k8files/nginx.conf /opt/nginx/conf/
 COPY --chmod=644 ./k8files/status.conf /opt/nginx/conf/sites.d/
-COPY ./k8files/pivcac.conf /opt/nginx/conf/sites.d/
+COPY ./k8files/pivcac.conf /opt/nginx/conf/sites.d/pivcac.conftemp
+
+# Download RDS Combined CA Bundles
+RUN wget -P /usr/local/share/aws/  https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
 
 # Create cron jobs
 RUN echo '* */4 * * * websrv flock -n /tmp/update_cert_revocations.lock -c /usr/local/bin/update_cert_revocations' > /etc/cron.d/update_cert_revocations; \
@@ -142,7 +146,7 @@ RUN mkdir -p ${RAILS_ROOT}/keys; chmod -R 0755 ${RAILS_ROOT}/keys; \
     mkdir -p ${RAILS_ROOT}/config/puma; chmod -R 0755 ${RAILS_ROOT}/config/puma; 
 COPY --chown=app --chmod=755 ./k8files/application.yml.default.docker ./config/application.yml
 COPY --chown=app --chmod=755 ./k8files/newrelic.yml ./config/newrelic.yml
-COPY --chown=app --chmod=755 ./k8files/puma_production ./config/puma/production.rb
+COPY --chown=app --chmod=755 ./k8files/puma_production ./config/puma/production.rbtemp
 
 # Expose port the app runs on
 EXPOSE 443

--- a/k8files/configure_environment
+++ b/k8files/configure_environment
@@ -31,6 +31,23 @@ else
   AWS_ACCOUNT_NUM="894947205914"
 fi
 
+# Set variables used to configure NGINX, SSL Certs, and Puma configuration
+
+if [[ "${ENV}" = "reviewapps" ]]; then
+  export ENV_CONFIG_PIVCAC_SSL_DOMAIN="${CERT_ENV}.pivcac.identitysandbox.gov"
+  export ENV_CONFIG_NGINX_SERVER_NAME="*.${ENV_CONFIG_PIVCAC_SSL_DOMAIN}"
+  CERT_DOMAIN="-d *.${ENV_CONFIG_PIVCAC_SSL_DOMAIN}"
+else
+  export ENV_CONFIG_PIVCAC_SSL_DOMAIN="pivcac.${CERT_ENV}.identitysandbox.gov"
+  export ENV_CONFIG_NGINX_SERVER_NAME="*.${ENV_CONFIG_PIVCAC_SSL_DOMAIN}"
+  CERT_DOMAIN="-d ${ENV_CONFIG_PIVCAC_SSL_DOMAIN} -d *.${ENV_CONFIG_PIVCAC_SSL_DOMAIN}"
+fi 
+
+if [[ -z "${CERT_DOMAIN:-}" ]]; then
+  echo "Certificate Domain did not get set properly. This error should not happen. Troubleshoot script"
+  exit 1
+fi
+
 # Configure nginx
 sudo chmod og+w /opt/nginx/conf/nginx.conf
 sudo chmod og+w /opt/nginx/conf
@@ -70,14 +87,21 @@ sudo -E -u root chown root: /etc/cron.d/update_letsencrypt_certs
 sudo -E -u root chmod 700 /etc/cron.d/update_letsencrypt_certs
 
 # Check if bundle exists/is not null
-sudo -E -u root [ -s /root/letsencrypt.${CERT_ENV}.tar.gz ] && sudo -E -u root tar zxf /root/letsencrypt.${CERT_ENV}.tar.gz -C /etc || sudo -E -u root certbot certonly --agree-tos -n --dns-route53 -d *.${CERT_ENV}.pivcac.identitysandbox.gov --email identity-devops@login.gov --server https://acme-v02.api.letsencrypt.org/directory --deploy-hook "/usr/local/bin/push_letsencrypt_certs.sh -e ${ENV} -c ${CERT_ENV}" --preferred-chain 'ISRG Root X1'  --key-type rsa --rsa-key-size 2048
+sudo -E -u root [ -s /root/letsencrypt.${CERT_ENV}.tar.gz ] && sudo -E -u root tar zxf /root/letsencrypt.${CERT_ENV}.tar.gz -C /etc || sudo -E -u root certbot certonly --agree-tos -n --dns-route53 ${CERT_DOMAIN} --email identity-devops@login.gov --server https://acme-v02.api.letsencrypt.org/directory --deploy-hook "/usr/local/bin/push_letsencrypt_certs.sh -e ${ENV} -c ${CERT_ENV}" --preferred-chain 'ISRG Root X1'  --key-type rsa --rsa-key-size 2048
 
 sudo -E -u root certbot renew -n --deploy-hook "/usr/local/bin/push_letsencrypt_certs.sh -e ${ENV} -c ${CERT_ENV}" --preferred-chain 'ISRG Root X1' --key-type rsa --rsa-key-size 2048
 
 # Update Letsencrypt folder permissions
 sudo -E -u root chmod 755 /etc/letsencrypt/live
 sudo -E -u root chmod 755 /etc/letsencrypt/archive
-sudo -E -u root chmod -R 755 /etc/letsencrypt/archive/review-app.pivcac.identitysandbox.gov/*
+sudo -E -u root chmod -R 755 /etc/letsencrypt/archive/${ENV_CONFIG_PIVCAC_SSL_DOMAIN}/*
+
+# Set Environment configuration in file
+envsubst '${ENV_CONFIG_PIVCAC_SSL_DOMAIN} ${ENV_CONFIG_NGINX_SERVER_NAME}' < /opt/nginx/conf/sites.d/pivcac.conftemp > ./pivcac.conftemp && \
+  sudo mv ./pivcac.conftemp /opt/nginx/conf/sites.d/pivcac.conf
+envsubst '${ENV_CONFIG_PIVCAC_SSL_DOMAIN}' < /app/config/puma/production.rbtemp > /app/config/puma/production.rb
+sudo rm -f /opt/nginx/conf/sites.d/pivcac.conftemp
+sudo rm -f /app/config/puma/production.rbtempd
 
 # Start nginx
 sudo -E -u root nginx

--- a/k8files/pivcac.conf
+++ b/k8files/pivcac.conf
@@ -11,11 +11,10 @@ add_header Strict-Transport-Security $sts_value always;
 
 server {
     listen        443 ssl;
-    server_name  *.review-app.pivcac.identitysandbox.gov;
+    server_name   ${ENV_CONFIG_NGINX_SERVER_NAME};
 
-
-    ssl_certificate      /etc/letsencrypt/live/review-app.pivcac.identitysandbox.gov/fullchain.pem;
-    ssl_certificate_key  /etc/letsencrypt/live/review-app.pivcac.identitysandbox.gov/privkey.pem;
+    ssl_certificate      /etc/letsencrypt/live/${ENV_CONFIG_PIVCAC_SSL_DOMAIN}/fullchain.pem;
+    ssl_certificate_key  /etc/letsencrypt/live/${ENV_CONFIG_PIVCAC_SSL_DOMAIN}/privkey.pem;
     ssl_verify_client optional_no_ca; # on;
     ssl_verify_depth 10;
 

--- a/k8files/puma_production
+++ b/k8files/puma_production
@@ -11,4 +11,4 @@ state_path "#{app_dir}/tmp/pids/puma.state"
 
 
 set_remote_address proxy_protocol: :v1
-bind "ssl://0.0.0.0:3001?key=/etc/letsencrypt/live/review-app.pivcac.identitysandbox.gov/privkey.pem&cert=/etc/letsencrypt/live/review-app.pivcac.identitysandbox.gov/fullchain.pem"
+bind "ssl://0.0.0.0:3001?key=/etc/letsencrypt/live/${ENV_CONFIG_PIVCAC_SSL_DOMAIN}/privkey.pem&cert=/etc/letsencrypt/live/${ENV_CONFIG_PIVCAC_SSL_DOMAIN}/fullchain.pem"

--- a/k8files/update_letsencrypt_certs
+++ b/k8files/update_letsencrypt_certs
@@ -33,12 +33,27 @@ else
   AWS_ACCOUNT_NUM="894947205914"
 fi
 
+# Set domains that PIVCAC cert will be requested for. Review-app environment uses a different domain structure
+# than other environments, so we test to see if ENV is reviewapp to set it's value, otherwise the domain follows
+# standard PIVCAC domain structure.
+CERT_DOMAIN=""
+if [[ "${ENV}" = "reviewapp" ]]; then
+  CERT_DOMAIN="-d *.${CERT_ENV}.pivcac.identitysandbox.gov"
+else
+  CERT_DOMAIN="-d pivcac.${CERT_ENV}.identitysandbox.gov -d *.pivcac.${CERT_ENV}.identitysandbox.gov"
+fi
+
+if [[ -z "${CERT_DOMAIN:-}" ]]; then
+  echo "Certificate Domain did not get set properly. This error should not happen. Troubleshoot script"
+  exit 1
+fi
+
 [ -e /root/letsencrypt.${CERT_ENV}.tar.gz ] && rm -f /root/letsencrypt.${CERT_ENV}.tar.gz
 
 aws s3 cp s3://login-gov-pivcac-${ENV}.${AWS_ACCOUNT_NUM}-us-west-2/letsencrypt.${CERT_ENV}.tar.gz /root/letsencrypt.${CERT_ENV}.tar.gz
 
 cd /etc/letsencrypt
 
-[ -s /root/letsencrypt.${CERT_ENV}.tar.gz ] && tar zxf /root/letsencrypt.${CERT_ENV}.tar.gz || certbot certonly --agree-tos -n --dns-route53 -d *.${CERT_ENV}.pivcac.identitysandbox.gov --email identity-devops@login.gov --server https://acme-v02.api.letsencrypt.org/directory --deploy-hook "/usr/local/bin/push_letsencrypt_certs.sh -e ${ENV} -c ${CERT_ENV}" --preferred-chain 'ISRG Root X1'  --key-type rsa --rsa-key-size 2048
+[ -s /root/letsencrypt.${CERT_ENV}.tar.gz ] && tar zxf /root/letsencrypt.${CERT_ENV}.tar.gz || certbot certonly --agree-tos -n --dns-route53 ${CERT_DOMAIN} --email identity-devops@login.gov --server https://acme-v02.api.letsencrypt.org/directory --deploy-hook "/usr/local/bin/push_letsencrypt_certs.sh -e ${ENV} -c ${CERT_ENV}" --preferred-chain 'ISRG Root X1'  --key-type rsa --rsa-key-size 2048
 
 certbot renew -n --deploy-hook "/usr/local/bin/push_letsencrypt_certs.sh -e ${ENV} -c ${CERT_ENV}" --preferred-chain 'ISRG Root X1' --key-type rsa --rsa-key-size 2048

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -18,8 +18,9 @@ namespace :certs do
   end
 
   desc 'Print expiring certs'
-  task print_expiring: :environment do
-    deadline = 30.days.from_now
+  task :print_expiring, [:deadline_days] => [:environment] do |t, args|
+    args.with_defaults(:deadline_days => 30)
+    deadline = args[:deadline_days].to_i.days.from_now
 
     cert_store = CertificateStore.instance
     cert_store.load_certs!(dir: Rails.root.join('config/certs'))

--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -158,10 +158,10 @@ RSpec.describe IdentifyController, type: :controller do
               openssl_errors: 'error 20 at 0 depth lookup: unable to get local issuer certificate',
               ficam_openssl_valid: false,
               ficam_openssl_errors: 'error 20 at 0 depth lookup: unable to get local issuer certificate',
+              matched_policy_oids: { '2.16.840.1.101.2.1.11.9' => true },
             }.to_json).once
 
             @request.headers['X-Client-Cert'] = CGI.escape(client_cert_pem)
-
 
             get :create, params: { nonce: '123', redirect_uri: 'http://example.com/' }
             expect(response).to have_http_status(:found)


### PR DESCRIPTION
## Internal
* LG-12240: Log matched policy OIDs (#437)
* Dockerfile updates for EKS environments (#428)
* Allow specifying days for expiration in print_expiring task and set it to zero in CI (#443)
* Install dependencies in setup with Homebrew (#439)
* Update keychain certificate instructions for latest macOS (#442)
* Add pull request template (#440)
* Expand troubleshooting advice for OpenSSL 1.1 (#438)
