### PR TITLE
LG-13300: Include key_id in valid certificate token

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -193,6 +193,7 @@ class Certificate
         subject: subject_s,
         issuer: issuer.to_s,
         uuid: piv.uuid,
+        key_id: key_id,
       )
     )
   end

--- a/spec/controllers/identify_controller_spec.rb
+++ b/spec/controllers/identify_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe IdentifyController, type: :controller do
             allow(OcspService).to receive(:new).and_return(ocsp_responder)
           end
 
-          it 'returns a token with a uuid and subject and logs certificate metadata' do
+          it 'returns a token with a uuid, subject, key id, and logs certificate metadata' do
             allow(IdentityConfig.store).to receive(:client_cert_escaped).and_return(true)
 
             cert = Certificate.new(client_cert)
@@ -169,6 +169,7 @@ RSpec.describe IdentifyController, type: :controller do
             expect(token).to be_truthy
 
             expect(token_contents['nonce']).to eq '123'
+            expect(token_contents['key_id']).to eq(cert.key_id)
 
             # N.B.: we do this split/sort because DNs match without respect to
             # ordering of components. OpenSSL::X509::Name doesn't match correctly.


### PR DESCRIPTION
## 🎫 Ticket

[LG-13300](https://cm-jira.usa.gov/browse/LG-13300)

## 🛠 Summary of changes

Updates the returned token for a valid certificate to include `key_id`, for consistency with [invalid certificates' response value](https://github.com/18F/identity-pki/blob/b7f6eed02da84146f70586899304703c8254a057/app/models/certificate.rb#L211), and to enable the IdP logging behavior expected in [LG-12946](https://cm-jira.usa.gov/browse/LG-12946) as of https://github.com/18F/identity-idp/pull/10512 .

## 📜 Testing Plan

1. Have this project and [`identity-idp`](https://github.com/18F/identity-idp) running concurrently
2. Ensure `identity_pki_disabled` is not set to `true` in your local IdP `config/application.yml` so that real PKI service is used
3. Have `make watch_events` running in a third terminal process within `identity-idp`
4. Go to http://localhost:3000
5. Sign in or create an account
6. Add a PIV when available
7. Check logs from the tab running `make watch_events` and find the "Multi-Factor Authentication Setup" event
8. Observe that `key_id` is a non-`null` value