### PR TITLE
Add Nix flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@
 
 CONFIG = config/application.yml
 PORT ?= 8442
+OS := $(shell uname)
+IS_NIXOS := $(shell grep -q NixOS /etc/os-release && echo true)
 
 all: check
 
@@ -41,5 +43,14 @@ lintfix:
 test: $(CONFIG)
 	bundle exec rspec
 
+ifeq ($(OS), Darwin)
 run:
 	foreman start -p $(PORT)
+else ifeq ($(OS), Linux)
+ifeq $(IS_NIXOS), true)
+run:
+	goreman start
+else
+	foreman start -p $(PORT)
+endif
+endif

--- a/config/local-certs/Makefile
+++ b/config/local-certs/Makefile
@@ -1,6 +1,9 @@
-.PHONY: keychain-import clean
+.PHONY: import-cert clean
 
-all: keychain-import server.crt
+all: import-cert server.crt
+
+OS := $(shell uname)
+IS_NIXOS := $(shell grep -q NixOS /etc/os-release && echo true)
 
 rootCA.key:
 	@echo "==="
@@ -25,10 +28,27 @@ rootCA.pem: rootCA.key
 		-days 1024 \
 		-out $@
 
-keychain-import: rootCA.pem
+ifeq ($(OS), Darwin)
+import-cert: rootCA.pem
+	@echo "Importing certificate on macOS..."
 	security find-certificate -c "identity-pki Development Certificate" >/dev/null 2>/dev/null || \
 		(security import $< -t pub -A)
-	@echo "NOTE: please open Keychain Access and set Trust settings to 'Always Trust' for 'identity-pki Development Certificate'"
+	@echo "NOTE: Please open Keychain Access and set Trust settings to 'Always Trust' for 'identity-pki Development Certificate'"
+else ifeq ($(OS), Linux)
+ifeq ($(IS_NIXOS), true)
+import-cert: rootCA.pem
+	@echo "Please add the certificate in your NixOS configuration:"
+	@echo "  security.pki.certificates = [ ./rootCA.pem ];"
+else
+import-cert: rootCA.pem
+	@echo "Importing certificate on Linux..."
+	@sudo cp -v rootCA.pem /usr/local/share/ca-certificates/identity-pki.pem
+	@sudo update-ca-certificates
+endif
+else
+import-cert:
+	@echo "Unsupported OS: $(OS)"
+endif
 
 server.key: server.csr.cnf
 	openssl req \
@@ -55,8 +75,22 @@ server.crt: server.key
 		-sha256 \
 		-extfile v3.ext
 
-clean:
-	rm -f rootCA.key rootCA.key server.key server.crt
+rm:
+	rm -fv rootCA.key rootCA.key server.key server.crt
+
+ifeq ($(OS), Darwin)
+clean: rm
 	@echo "NOTE: Please open Keychain Access and manually delete 'identity-pki Development Certificate'"
 	# TODO: doesn't seem to remove from the UI when we run this:
 	# 	security delete-certificate -t -c "identity-pki Development Certificate"
+else ifeq ($(OS), Linux)
+ifeq ($(IS_NIXOS), true)
+clean: rm
+	@echo "NOTE: Please remove the certificate from your NixOS configuration:"
+	@echo "  security.pki.certificates = [ ./rootCA.pem ];"
+else
+clean: rm
+	@sudo rm -fv /usr/local/share/ca-certificates/identity-pki.pem
+	@sudo update-ca-certificates
+endif
+endif

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "DevShell for identity-pki";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+
+    flake-utils.lib.eachDefaultSystem (
+      system:
+
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      {
+        devShell =
+          with pkgs;
+
+          mkShell {
+            buildInputs = [
+              ruby
+              yarn
+              postgresql.dev
+              goreman # Use goreman since nginx launch will fail gracefully and launch Puma, as opposed to when using foreman
+              # nginx
+            ];
+
+            shellHook = ''
+              export PKG_CONFIG_PATH="${pkgs.postgresql.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
+            '';
+          };
+      }
+    );
+}


### PR DESCRIPTION
For developers wishing to develop identity-pki using a Nix environment.

Adds some OS-detection logic, for Darwin, general Linux and NixOS, specifically.

Use goreman instead of foreman, since foreman will exit if nginx cannot launch, which might not work at least on NixOS, since nginx requires /var/log/nginx to exist, at least.

make setup and run work, but flake may be missing a dependency or two.